### PR TITLE
feat: multi-worktree Docker isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ TODO.md
 
 # Claude action log
 ACTION-LOG.md
+
+# Environment files
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ ACTION-LOG.md
 
 # Environment files
 .env
+.claude/worktrees/

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -54,6 +54,7 @@
         "LintServerFix",
         "LintServerVerify",
         "PathsCleanDirectories",
+        "PathsShowWorktreeInfo",
         "RunLocalClient",
         "RunLocalDependencies",
         "RunLocalDependenciesDown",

--- a/App/Client/package-lock.json
+++ b/App/Client/package-lock.json
@@ -22,6 +22,7 @@
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^25.5.0",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
         "@vitejs/plugin-react": "^5.0.3",
@@ -2564,6 +2565,17 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.1.14",
@@ -6035,6 +6047,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/App/Client/package.json
+++ b/App/Client/package.json
@@ -28,6 +28,7 @@
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^25.5.0",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@vitejs/plugin-react": "^5.0.3",

--- a/App/Client/tsconfig.node.json
+++ b/App/Client/tsconfig.node.json
@@ -4,7 +4,7 @@
     "target": "ES2023",
     "lib": ["ES2023"],
     "module": "ESNext",
-    "types": [],
+    "types": ["node"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/App/Client/vite.config.ts
+++ b/App/Client/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:5000',
+        target: process.env.VITE_API_URL || 'http://localhost:5000',
         changeOrigin: true,
       },
     },

--- a/App/Server/src/Server.Web/Configurations/ServiceConfigs.cs
+++ b/App/Server/src/Server.Web/Configurations/ServiceConfigs.cs
@@ -93,11 +93,19 @@ public static class ServiceConfigs
     .AddBearerToken(IdentityConstants.BearerScheme)
     .AddCookie(IdentityConstants.ApplicationScheme);
 
+    // Scope cookie names by instance so multiple worktrees on localhost don't collide
+    var cookieSuffix = builder.Configuration["CookieSuffix"] ?? string.Empty;
+
+    services.ConfigureApplicationCookie(options =>
+    {
+      options.Cookie.Name = $".AspNetCore.Identity.Application{cookieSuffix}";
+    });
+
     // Configure CSRF protection for cookie-based authentication
     services.AddAntiforgery(options =>
     {
       options.HeaderName = "X-XSRF-TOKEN";
-      options.Cookie.Name = "XSRF-TOKEN";
+      options.Cookie.Name = $"XSRF-TOKEN{cookieSuffix}";
       options.Cookie.HttpOnly = false; // Client needs to read it
       options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
       options.Cookie.SameSite = SameSiteMode.Strict;

--- a/Task/LocalDev/docker-compose.dev-deps.yml
+++ b/Task/LocalDev/docker-compose.dev-deps.yml
@@ -5,7 +5,7 @@ services:
       ACCEPT_EULA: "Y"
       SEQ_FIRSTRUN_NOAUTHENTICATION: "true"
     ports:
-      - "5341:80"
+      - "${PORT_SEQ:-5341}:80"
     volumes:
       - seq-data:/data
     networks:
@@ -19,7 +19,7 @@ services:
     environment:
       SEQ_ADDRESS: "http://seq:5341"
     ports:
-      - "12201:12201/udp"
+      - "${PORT_GELF:-12201}:12201/udp"
     networks:
       - app-network
 
@@ -32,7 +32,7 @@ services:
       SA_PASSWORD: "YourStrong@Passw0rd"
       MSSQL_PID: "Express"
     ports:
-      - "1433:1433"
+      - "${PORT_SQL:-1433}:1433"
     healthcheck:
       test: ["CMD", "/opt/mssql-tools18/bin/sqlcmd", "-S", "localhost", "-U", "sa", "-P", "YourStrong@Passw0rd", "-Q", "SELECT 1", "-C"]
       interval: 3s
@@ -44,7 +44,7 @@ services:
     logging:
       driver: gelf
       options:
-        gelf-address: "udp://127.0.0.1:12201"
+        gelf-address: "udp://127.0.0.1:${PORT_GELF:-12201}"
         tag: "{{.Name}}"
     networks:
       - app-network
@@ -54,8 +54,8 @@ services:
     environment:
       COLLECTOR_OTLP_ENABLED: "true"
     ports:
-      - "4317:4317"
-      - "16686:16686"
+      - "${PORT_OTLP:-4317}:4317"
+      - "${PORT_JAEGER_UI:-16686}:16686"
     networks:
       - app-network
 
@@ -68,7 +68,7 @@ services:
       - ./config/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus-data:/prometheus
     ports:
-      - "9090:9090"
+      - "${PORT_PROMETHEUS:-9090}:9090"
     networks:
       - app-network
 
@@ -97,7 +97,7 @@ services:
       - ./config/grafana/dashboards:/etc/grafana/provisioning/dashboards/json
       - grafana-data:/var/lib/grafana
     ports:
-      - "3000:3000"
+      - "${PORT_GRAFANA:-3000}:3000"
     depends_on:
       - jaeger
       - prometheus
@@ -113,4 +113,4 @@ volumes:
 networks:
   app-network:
     external: true
-    name: app-network
+    name: ${NETWORK_NAME:-app-network}

--- a/Task/LocalDev/docker-compose.publish.yml
+++ b/Task/LocalDev/docker-compose.publish.yml
@@ -14,6 +14,7 @@ services:
       Serilog__WriteTo__1__Args__Path: /app/Logs/RunLocalPublish/Server.Web/Serilog/logs.json
       Serilog__WriteTo__2__Args__ServerUrl: http://seq:80
       OpenTelemetry__OtlpEndpoint: "http://jaeger:4317"
+      CookieSuffix: "${COOKIE_SUFFIX:-}"
     ports:
       - "${PORT_API_HTTP:-5000}:5000"
       - "${PORT_API_HTTPS:-5001}:5001"

--- a/Task/LocalDev/docker-compose.publish.yml
+++ b/Task/LocalDev/docker-compose.publish.yml
@@ -1,6 +1,6 @@
 services:
   api:
-    image: conduit-localdev-api:local
+    image: conduit-localdev-api:${IMAGE_TAG:-local}
     build:
       context: ../../
       dockerfile: Task/LocalDev/Dockerfile.publish
@@ -15,8 +15,8 @@ services:
       Serilog__WriteTo__2__Args__ServerUrl: http://seq:80
       OpenTelemetry__OtlpEndpoint: "http://jaeger:4317"
     ports:
-      - "5000:5000"
-      - "5001:5001"
+      - "${PORT_API_HTTP:-5000}:5000"
+      - "${PORT_API_HTTPS:-5001}:5001"
     volumes:
       - ../../Logs:/app/Logs
     healthcheck:
@@ -31,4 +31,4 @@ services:
 networks:
   app-network:
     external: true
-    name: app-network
+    name: ${NETWORK_NAME:-app-network}

--- a/Task/Runner/Nuke/Build.Db.cs
+++ b/Task/Runner/Nuke/Build.Db.cs
@@ -65,7 +65,7 @@ public partial class Build
 
   internal void ResetDatabase()
   {
-    if (DoesDockerVolumeExist(Constants.Docker.Volumes.SqlServer))
+    if (DoesDockerVolumeExist(SqlServerVolumeName))
     {
       Log.Information("Detected SQL Server docker volume. Removing volume to reset database...");
       RemoveSqlServerVolume();
@@ -95,11 +95,18 @@ public partial class Build
     {
       // Stop any running containers first
       Log.Information("Stopping SQL Server container if running...");
-      DockerTasks.Docker($"compose -f {DockerComposeDependencies} -p {Constants.Docker.Projects.DevDependencies} down", workingDirectory: RootDirectory);
+      var envVars = GetWorktreeEnvVars();
+      var args = $"compose -f {DockerComposeDependencies} -p {ScopedProjectName(Constants.Docker.Projects.DevDependencies)} down";
+      var process = ProcessTasks.StartProcess(
+        "docker",
+        args,
+        workingDirectory: RootDirectory,
+        environmentVariables: envVars);
+      process.WaitForExit();
 
       // Remove the volume
       Log.Information("Removing SQL Server docker volume...");
-      DockerTasks.DockerVolumeRm(_ => _.SetVolumes(Constants.Docker.Volumes.SqlServer));
+      DockerTasks.DockerVolumeRm(_ => _.SetVolumes(SqlServerVolumeName));
 
       Log.Information("✓ SQL Server database reset complete - docker volume removed");
     }

--- a/Task/Runner/Nuke/Build.Install.cs
+++ b/Task/Runner/Nuke/Build.Install.cs
@@ -1,5 +1,4 @@
-﻿using Nuke;
-using Nuke.Common;
+﻿using Nuke.Common;
 using Nuke.Common.IO;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.Docker;
@@ -93,10 +92,10 @@ public partial class Build
       });
 
   internal Target InstallDockerNetwork => _ => _
-    .Description($"Creates {Constants.Docker.Networks.AppNetwork} docker network which is a shared global network")
+    .Description("Creates the Docker network for this worktree instance")
     .Executes(() =>
     {
-      var name = Constants.Docker.Networks.AppNetwork;
+      var name = ScopedNetworkName;
 
       var existing = DockerTasks.DockerNetworkLs(s => s
           .SetFilter($"name=^{name}$")

--- a/Task/Runner/Nuke/Build.Paths.cs
+++ b/Task/Runner/Nuke/Build.Paths.cs
@@ -119,6 +119,10 @@ public partial class Build
   internal AbsolutePath LogsTestServerPostman => RootDirectory / "Logs" / "Test" / "Postman";
   #endregion
 
+  internal Target PathsShowWorktreeInfo => _ => _
+    .Description("Show worktree isolation info: slug, port offset, and all port mappings")
+    .Executes(LogWorktreeInfo);
+
   internal Target PathsCleanDirectories => _ => _
     .Description("Pre-create directories that Docker containers need to prevent root permission issues")
     .Executes(() =>

--- a/Task/Runner/Nuke/Build.RunLocal.cs
+++ b/Task/Runner/Nuke/Build.RunLocal.cs
@@ -4,7 +4,6 @@ using Nuke;
 using Nuke.Common;
 using Nuke.Common.IO;
 using Nuke.Common.Tooling;
-using Nuke.Common.Tools.Docker;
 using Nuke.Common.Tools.Npm;
 using Serilog;
 using static Nuke.Common.Tools.Npm.NpmTasks;
@@ -27,15 +26,16 @@ public partial class Build
     .Executes(() =>
     {
       Log.Information("Starting local development environment with Docker Compose (published artifact)...");
+      LogWorktreeInfo();
 
-      var envVars = new Dictionary<string, string>
+      var envVars = new Dictionary<string, string>(GetWorktreeEnvVars())
       {
         ["DOCKER_BUILDKIT"] = "1",
       };
 
       var detached = Agent ? " -d" : string.Empty;
       Log.Information("Running Docker Compose for local development with published artifact...");
-      var args = $"compose -f {DockerComposePublish} -p {Constants.Docker.Projects.App} up --build{detached}";
+      var args = $"compose -f {DockerComposePublish} -p {ScopedProjectName(Constants.Docker.Projects.App)} up --build{detached}";
       var process = ProcessTasks.StartProcess(
             "docker",
             args,
@@ -49,7 +49,14 @@ public partial class Build
     .Executes(() =>
     {
       Log.Information("Stopping local published app containers...");
-      DockerTasks.Docker($"compose -f {DockerComposePublish} -p {Constants.Docker.Projects.App} down", workingDirectory: RootDirectory);
+      var envVars = GetWorktreeEnvVars();
+      var args = $"compose -f {DockerComposePublish} -p {ScopedProjectName(Constants.Docker.Projects.App)} down";
+      var process = ProcessTasks.StartProcess(
+        "docker",
+        args,
+        workingDirectory: RootDirectory,
+        environmentVariables: envVars);
+      process.WaitForExit();
     });
 
   internal Target RunLocalDependencies => _ => _
@@ -59,15 +66,15 @@ public partial class Build
     {
       Log.Information("Starting dev dependencies");
 
-      var envVars = new Dictionary<string, string>
+      var envVars = new Dictionary<string, string>(GetWorktreeEnvVars())
       {
         ["DOCKER_BUILDKIT"] = "1",
       };
 
       try
       {
-        Log.Information("Running Docker Compose for local development with published artifact...");
-        var args = $"compose -f {DockerComposeDependencies} -p {Constants.Docker.Projects.DevDependencies} up -d";
+        Log.Information("Running Docker Compose for dev dependencies...");
+        var args = $"compose -f {DockerComposeDependencies} -p {ScopedProjectName(Constants.Docker.Projects.DevDependencies)} up -d";
         var process = ProcessTasks.StartProcess(
           "docker",
           args,
@@ -83,11 +90,18 @@ public partial class Build
     });
 
   internal Target RunLocalDependenciesDown => _ => _
-    .Description("stop dev dependencies")
+    .Description("Stop dev dependencies")
     .Executes(() =>
     {
       Log.Information("Stopping dev dependencies");
-      DockerTasks.Docker($"compose -f {DockerComposeDependencies} -p {Constants.Docker.Projects.DevDependencies} down", workingDirectory: RootDirectory);
+      var envVars = GetWorktreeEnvVars();
+      var args = $"compose -f {DockerComposeDependencies} -p {ScopedProjectName(Constants.Docker.Projects.DevDependencies)} down";
+      var process = ProcessTasks.StartProcess(
+        "docker",
+        args,
+        workingDirectory: RootDirectory,
+        environmentVariables: envVars);
+      process.WaitForExit();
     });
 
   internal Target RunLocalClient => _ => _
@@ -95,10 +109,13 @@ public partial class Build
     .DependsOn(InstallClient)
     .Executes(() =>
     {
-      Log.Information($"Starting Vite dev server in {ClientDirectory}");
+      var offset = Constants.Worktree.GetPortOffset(RootDirectory);
+      var apiPort = 5000 + offset;
+      Log.Information("Starting Vite dev server in {ClientDirectory} (API proxy → http://localhost:{ApiPort})", ClientDirectory, apiPort);
       NpmRun(s => s
         .SetProcessWorkingDirectory(ClientDirectory)
-        .SetCommand("dev"));
+        .SetCommand("dev")
+        .SetProcessEnvironmentVariable("VITE_API_URL", $"http://localhost:{apiPort}"));
     });
 
   internal Target RunLocalDocsMcpServerUp => _ => _
@@ -121,13 +138,14 @@ public partial class Build
 
       // Start Docs MCP Server in the background
       Log.Information("Starting Docs MCP Server in the background...");
-      var mcpProcess = StartBackgroundProcess("npx", "--yes @arabold/docs-mcp-server@latest");
+      var mcpProcess = StartBackgroundProcess("npx", $"--yes @arabold/docs-mcp-server@latest --port {DocsMcpPort}");
       DocsMcpPidFile.WriteAllText(mcpProcess.Id.ToString());
       Log.Information("Docs MCP Server started with PID: {PID}", mcpProcess.Id);
 
       // Wait for the server to be available
-      Log.Information("Waiting for Docs MCP Server to be available at http://127.0.0.1:6280...");
-      if (!WaitForHttpEndpoint("http://127.0.0.1:6280", timeoutSeconds: 15))
+      var mcpUrl = $"http://127.0.0.1:{DocsMcpPort}";
+      Log.Information("Waiting for Docs MCP Server to be available at {Url}...", mcpUrl);
+      if (!WaitForHttpEndpoint(mcpUrl, timeoutSeconds: 15))
       {
         Log.Error("Docs MCP Server did not become available within the timeout period");
 
@@ -137,7 +155,7 @@ public partial class Build
         throw new Exception("Docs MCP Server failed to start - try run npx @arabold/docs-mcp-server@latest");
       }
 
-      Log.Information("✓ Docs MCP Server is available at http://127.0.0.1:6280");
+      Log.Information("✓ Docs MCP Server is available at {Url}", mcpUrl);
 
       // Check if ngrok is available
       if (!IsCommandAvailable("ngrok"))
@@ -146,14 +164,14 @@ public partial class Build
         Log.Warning("Install ngrok from https://ngrok.com/download");
         Log.Warning("Continuing without ngrok...");
         Log.Information("✓ Docs MCP Server started successfully (without ngrok)");
-        Log.Information("  Docs MCP Server: http://127.0.0.1:6280");
+        Log.Information("  Docs MCP Server: http://127.0.0.1:{Port}", DocsMcpPort);
         Log.Information("  PID files stored in: {PidDirectory}", PidDirectory);
         return;
       }
 
       // Start ngrok in the background
       Log.Information("Starting ngrok in the background...");
-      var ngrokProcess = StartBackgroundProcess("ngrok", "http 6280 --url noncognizably-chartographical-fae.ngrok-free.app");
+      var ngrokProcess = StartBackgroundProcess("ngrok", $"http {DocsMcpPort} --url noncognizably-chartographical-fae.ngrok-free.app");
       NgrokPidFile.WriteAllText(ngrokProcess.Id.ToString());
       Log.Information("ngrok started with PID: {PID}", ngrokProcess.Id);
 
@@ -162,7 +180,7 @@ public partial class Build
       System.Threading.Thread.Sleep(3000);
 
       Log.Information("✓ Services started successfully");
-      Log.Information("  Docs MCP Server: http://127.0.0.1:6280");
+      Log.Information("  Docs MCP Server: http://127.0.0.1:{Port}", DocsMcpPort);
       Log.Information("  ngrok: https://noncognizably-chartographical-fae.ngrok-free.app");
       Log.Information("  PID files stored in: {PidDirectory}", PidDirectory);
     });
@@ -223,9 +241,9 @@ public partial class Build
       Log.Information("Verifying services are stopped...");
       System.Threading.Thread.Sleep(1000);
 
-      if (IsHttpEndpointAvailable("http://127.0.0.1:6280"))
+      if (IsHttpEndpointAvailable($"http://127.0.0.1:{DocsMcpPort}"))
       {
-        var error = "Docs MCP Server is still accessible at http://127.0.0.1:6280";
+        var error = $"Docs MCP Server is still accessible at http://127.0.0.1:{DocsMcpPort}";
         Log.Error(error);
         errors.Add(error);
       }

--- a/Task/Runner/Nuke/Build.Test.cs
+++ b/Task/Runner/Nuke/Build.Test.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using Nuke;
 using Nuke.Common;
 using Nuke.Common.IO;
 using Nuke.Common.Tooling;
@@ -31,11 +32,14 @@ public partial class Build
         var testFailed = false;
         try
         {
+          var sqlPort = 1433 + Constants.Worktree.GetPortOffset(RootDirectory);
+          var connectionString = $"Server=localhost,{sqlPort};Database=Conduit;User Id=sa;Password=YourStrong@Passw0rd;TrustServerCertificate=True;MultipleActiveResultSets=true";
           DotNetTest(s => s
                 .SetProjectFile(ServerSolution)
                 .SetLoggers("trx")
                 .SetResultsDirectory(ReportsServerResultsDirectory)
                 .SetSettingsFile(RootDirectory / "App" / "Server" / "coverlet.runsettings")
+                .SetProcessEnvironmentVariable("ConnectionStrings__DefaultConnection", connectionString)
                 .AddProcessAdditionalArguments(
                   "--collect:\"XPlat Code Coverage\"",
                   "--",
@@ -197,7 +201,7 @@ public partial class Build
       int exitCode = 0;
       try
       {
-        var envVars = new Dictionary<string, string> { ["DOCKER_BUILDKIT"] = "1", };
+        var envVars = new Dictionary<string, string>(GetWorktreeEnvVars()) { ["DOCKER_BUILDKIT"] = "1", };
         var process = ProcessTasks.StartProcess(
           "docker",
           upArgs,
@@ -217,10 +221,12 @@ public partial class Build
       finally
       {
         // Start docker compose down in background while report generation proceeds
+        var downEnvVars = GetWorktreeEnvVars();
         var downProcess = ProcessTasks.StartProcess(
           "docker",
           downArgs,
           workingDirectory: RootDirectory,
+          environmentVariables: downEnvVars,
           logOutput: !Agent);
 
         // Generate LiquidTestReport from TRX files in parallel with compose down
@@ -302,7 +308,7 @@ public partial class Build
     int exitCode = 0;
     try
     {
-      var envVars = new Dictionary<string, string> { ["DOCKER_BUILDKIT"] = "1", };
+      var envVars = new Dictionary<string, string>(GetWorktreeEnvVars()) { ["DOCKER_BUILDKIT"] = "1", };
       var process = ProcessTasks.StartProcess(
         "docker",
         upArgs,
@@ -321,10 +327,12 @@ public partial class Build
     }
     finally
     {
+      var downEnvVars = GetWorktreeEnvVars();
       var downProcess = ProcessTasks.StartProcess(
         "docker",
         downArgs,
         workingDirectory: RootDirectory,
+        environmentVariables: downEnvVars,
         logOutput: !Agent);
 
       var reportFile = ReportsTestE2eArtifactsDirectory / "Report.md";
@@ -429,7 +437,7 @@ public partial class Build
   {
     Log.Information("Running Postman {CollectionName} tests with Docker Compose{BailSuffix}", collectionName, Bail ? " (with --bail)" : string.Empty);
 
-    var envVars = new Dictionary<string, string>
+    var envVars = new Dictionary<string, string>(GetWorktreeEnvVars())
     {
       ["DOCKER_BUILDKIT"] = "1",
     };
@@ -463,7 +471,7 @@ public partial class Build
     }
     finally
     {
-      var downEnvVars = new Dictionary<string, string>
+      var downEnvVars = new Dictionary<string, string>(GetWorktreeEnvVars())
       {
         ["DOCKER_BUILDKIT"] = "1",
       };

--- a/Task/Runner/Nuke/Build.Worktree.cs
+++ b/Task/Runner/Nuke/Build.Worktree.cs
@@ -19,6 +19,7 @@ public partial class Build
       ["PORT_GRAFANA"] = (3000 + offset).ToString(),
       ["NETWORK_NAME"] = ScopedNetworkName,
       ["IMAGE_TAG"] = Constants.Worktree.IsMainCheckout(RootDirectory) ? "local" : Constants.Worktree.GetSlug(RootDirectory),
+      ["COOKIE_SUFFIX"] = Constants.Worktree.IsMainCheckout(RootDirectory) ? string.Empty : $".{Constants.Worktree.GetSlug(RootDirectory)}",
     };
   }
 

--- a/Task/Runner/Nuke/Build.Worktree.cs
+++ b/Task/Runner/Nuke/Build.Worktree.cs
@@ -1,0 +1,62 @@
+﻿using Nuke;
+using Serilog;
+
+public partial class Build
+{
+  internal Dictionary<string, string> GetWorktreeEnvVars()
+  {
+    var offset = Constants.Worktree.GetPortOffset(RootDirectory);
+    return new Dictionary<string, string>
+    {
+      ["PORT_API_HTTP"] = (5000 + offset).ToString(),
+      ["PORT_API_HTTPS"] = (5001 + offset).ToString(),
+      ["PORT_SQL"] = (1433 + offset).ToString(),
+      ["PORT_SEQ"] = (5341 + offset).ToString(),
+      ["PORT_GELF"] = (12201 + offset).ToString(),
+      ["PORT_OTLP"] = (4317 + offset).ToString(),
+      ["PORT_JAEGER_UI"] = (16686 + offset).ToString(),
+      ["PORT_PROMETHEUS"] = (9090 + offset).ToString(),
+      ["PORT_GRAFANA"] = (3000 + offset).ToString(),
+      ["NETWORK_NAME"] = ScopedNetworkName,
+      ["IMAGE_TAG"] = Constants.Worktree.IsMainCheckout(RootDirectory) ? "local" : Constants.Worktree.GetSlug(RootDirectory),
+    };
+  }
+
+  internal string ScopedProjectName(string baseName)
+  {
+    return Constants.Worktree.ScopedName(RootDirectory, baseName);
+  }
+
+  internal string ScopedNetworkName => Constants.Worktree.ScopedName(RootDirectory, Constants.Docker.Networks.AppNetwork);
+
+  internal string SqlServerVolumeName => $"{ScopedProjectName(Constants.Docker.Projects.DevDependencies)}_sqlserver-data";
+
+  internal int DocsMcpPort => 6280 + Constants.Worktree.GetPortOffset(RootDirectory);
+
+  internal void LogWorktreeInfo()
+  {
+    var offset = Constants.Worktree.GetPortOffset(RootDirectory);
+    var slug = Constants.Worktree.GetSlug(RootDirectory);
+    var isMain = Constants.Worktree.IsMainCheckout(RootDirectory);
+
+    Log.Information("Worktree Info:");
+    Log.Information("  Root:       {Root}", RootDirectory);
+    Log.Information("  Slug:       {Slug}", slug);
+    Log.Information("  Main:       {IsMain}", isMain);
+    Log.Information("  Offset:     {Offset}", offset);
+    Log.Information("  Network:    {Network}", ScopedNetworkName);
+    Log.Information("  Image Tag:  {Tag}", isMain ? "local" : slug);
+    Log.Information("  Volume:     {Volume}", SqlServerVolumeName);
+    Log.Information("Port Mappings:");
+    Log.Information("  API HTTP:   {Port}", 5000 + offset);
+    Log.Information("  API HTTPS:  {Port}", 5001 + offset);
+    Log.Information("  SQL Server: {Port}", 1433 + offset);
+    Log.Information("  Seq:        {Port}", 5341 + offset);
+    Log.Information("  GELF:       {Port}", 12201 + offset);
+    Log.Information("  OTLP:       {Port}", 4317 + offset);
+    Log.Information("  Jaeger UI:  {Port}", 16686 + offset);
+    Log.Information("  Prometheus: {Port}", 9090 + offset);
+    Log.Information("  Grafana:    {Port}", 3000 + offset);
+    Log.Information("  Docs MCP:   {Port}", DocsMcpPort);
+  }
+}

--- a/Task/Runner/Nuke/Constants.cs
+++ b/Task/Runner/Nuke/Constants.cs
@@ -1,4 +1,7 @@
-﻿namespace Nuke;
+﻿using System.Text;
+using Nuke.Common.IO;
+
+namespace Nuke;
 
 public static class Constants
 {
@@ -18,6 +21,61 @@ public static class Constants
     public static class Volumes
     {
       public const string SqlServer = $"{Projects.DevDependencies}_sqlserver-data";
+    }
+  }
+
+  public static class Worktree
+  {
+    private const string WorktreeMarker = ".claude/worktrees/";
+
+    public static string GetSlug(AbsolutePath rootDir)
+    {
+      return ((string)rootDir).Split('/').Last().ToLowerInvariant();
+    }
+
+    public static bool IsMainCheckout(AbsolutePath rootDir)
+    {
+      return !((string)rootDir).Contains(WorktreeMarker);
+    }
+
+    public static int GetPortOffset(AbsolutePath rootDir)
+    {
+      if (IsMainCheckout(rootDir))
+      {
+        return 0;
+      }
+
+      var slug = GetSlug(rootDir);
+      var hash = Fnv1A(slug);
+
+      // Map to range [100, 9900] in steps of 100
+      var bucket = (int)(hash % 99) + 1;
+      return bucket * 100;
+    }
+
+    public static string ScopedName(AbsolutePath rootDir, string baseName)
+    {
+      if (IsMainCheckout(rootDir))
+      {
+        return baseName;
+      }
+
+      return $"{GetSlug(rootDir)}-{baseName}";
+    }
+
+    private static uint Fnv1A(string input)
+    {
+      const uint fnvOffsetBasis = 2166136261;
+      const uint fnvPrime = 16777619;
+
+      var hash = fnvOffsetBasis;
+      foreach (var b in Encoding.UTF8.GetBytes(input))
+      {
+        hash ^= b;
+        hash *= fnvPrime;
+      }
+
+      return hash;
     }
   }
 }

--- a/Test/Postman/docker-compose.yml
+++ b/Test/Postman/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       SA_PASSWORD: "YourStrong@Passw0rd"
       MSSQL_PID: "Express"
     ports:
-      - "1433:1433"
+      - "${PORT_SQL:-1433}:1433"
     healthcheck:
       test: ["CMD", "/opt/mssql-tools18/bin/sqlcmd", "-S", "localhost", "-U", "sa", "-P", "YourStrong@Passw0rd", "-Q", "SELECT 1", "-C"]
       interval: 3s
@@ -15,7 +15,7 @@ services:
       start_period: 5s
 
   api:
-    image: conduit-postman-api:local
+    image: conduit-postman-api:${IMAGE_TAG:-local}
     build:
       context: ../../
       dockerfile: Test/Postman/Dockerfile
@@ -27,7 +27,7 @@ services:
       ASPNETCORE_URLS: http://+:5000
       ConnectionStrings__DefaultConnection: "Server=sqlserver,1433;Database=Conduit;User Id=sa;Password=YourStrong@Passw0rd;TrustServerCertificate=True;MultipleActiveResultSets=true"
     ports:
-      - "5000:5000"
+      - "${PORT_API_HTTP:-5000}:5000"
     volumes:
       - ../../Logs:/app/Logs
     healthcheck:

--- a/Test/e2e/docker-compose.yml
+++ b/Test/e2e/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       start_period: 5s
 
   api:
-    image: conduit-e2e-api:local
+    image: conduit-e2e-api:${IMAGE_TAG:-local}
     build:
       context: ../../
       dockerfile: Test/e2e/Dockerfile.api
@@ -31,8 +31,8 @@ services:
       Audit__LogsPath: /app/Logs/Test/e2e/Server.Web/Audit.NET
       Serilog__WriteTo__1__Args__Path: /app/Logs/Test/e2e/Server.Web/Serilog/logs.txt
     ports:
-      - "5000:5000"
-      - "5001:5001"
+      - "${PORT_API_HTTP:-5000}:5000"
+      - "${PORT_API_HTTPS:-5001}:5001"
     volumes:
       - ../../Logs:/app/Logs
     healthcheck:
@@ -43,7 +43,7 @@ services:
       start_period: 10s
 
   playwright:
-    image: conduit-e2e-playwright:local
+    image: conduit-e2e-playwright:${IMAGE_TAG:-local}
     build:
       context: ./
       dockerfile: Dockerfile.playwright


### PR DESCRIPTION
## Summary
- Derive a unique slug from the repo root directory path to scope Docker project names, network names, image tags, and compute deterministic port offsets (FNV-1a hash)
- Main checkout keeps offset=0 with all default ports — full backward compatibility
- Worktrees get offset 100–9900, scoping all 12 host ports, Docker networks, volumes, container names, and auth cookies
- Tested simultaneously running two instances with independent login sessions on `localhost:5001` and `localhost:6401`

## Changes
- **`Constants.cs`**: `Worktree` class with `GetSlug`, `IsMainCheckout`, `GetPortOffset`, `ScopedName`
- **`Build.Worktree.cs`** (new): `GetWorktreeEnvVars()`, `ScopedProjectName()`, `SqlServerVolumeName`, `DocsMcpPort`, `LogWorktreeInfo()`
- **4 Docker Compose files**: `${VAR:-default}` syntax for all host ports, network names, image tags
- **4 Nuke build files**: Pass worktree env vars to all `ProcessTasks.StartProcess()` compose invocations
- **`ServiceConfigs.cs`**: `CookieSuffix` config to scope Identity + XSRF cookies per instance
- **`vite.config.ts`**: `VITE_API_URL` env var for proxy target
- **`.gitignore`**: Added `.env` and `.claude/worktrees/`

## Test plan
- [x] `PathsShowWorktreeInfo` in main → offset=0, default ports
- [x] `PathsShowWorktreeInfo` in worktree → offset=1400, shifted ports
- [x] `RunLocalPublish` in both simultaneously → no port conflicts
- [x] Health checks pass on both `localhost:5001` and `localhost:6401`
- [x] Seq, Grafana accessible on both default and offset ports
- [x] Independent browser login sessions (no cookie collision)
- [x] Clean teardown of each instance independently
- [x] `LintAllVerify` passes (Nuke, Server, Client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)