### PR TITLE
feat: trace-based eval system with TestCoverage annotations

### DIFF
--- a/.claude/rules/spec-writing.md
+++ b/.claude/rules/spec-writing.md
@@ -1,0 +1,58 @@
+---
+paths:
+  - "SPEC-REFERENCE.md"
+  - "Docs/**"
+---
+
+## Spec Writing — Required Sections
+
+A complete spec covers both API and frontend behavior. Missing either causes eval coverage gaps.
+
+### API Sections (per endpoint)
+- Method, path, auth requirements
+- Request body with field constraints (required, min/max, format)
+- Success response with example JSON
+- Every error response with exact trigger condition
+- Business rules (idempotency, side effects, ordering, defaults)
+
+### Frontend UI Behaviors (required sections)
+
+**Navigation & Layout** — links per role, role-restricted access behavior
+
+**Route Guards** — every protected route + redirect target. Distinct from API 401.
+- Bad: "API returns 401 for unauthenticated users"
+- Good: "Unauthenticated user navigating to /editor is redirected to /login by the frontend route guard"
+
+**Error Display** — how API errors appear in the UI. Distinct from error response format.
+- Bad: "Returns 400 with error for 'email'"
+- Good: "Error message 'already been registered with that email' is displayed in the registration form"
+
+**Mobile Responsive** — document separately from desktop:
+- Layout changes at mobile breakpoints
+- Hamburger menu open/close/auto-close behavior
+- Touch-specific interactions
+
+**Page-Specific Interactions** — frontend-only behaviors:
+- Default tab/state on page load
+- Pagination UI navigation (clicking pages, not API limit/offset)
+- Form interactions (tag chips, auto-submit keys, pre-population on edit)
+- Feature flag gated content (both enabled and disabled states)
+
+**Admin/Management Pages** — tables, modals, self-protection rules in UI
+
+**i18n** — how language changes, what elements translate
+
+**Screenshots** — enumerate each page/state individually, including mobile viewports.
+- Bad: "Visual regression tests for key pages"
+- Good: "Mobile viewport (375x667): Login page, Register page, Settings page"
+
+### Self-Check
+
+Before finalizing a spec, verify:
+1. Every route in router config has a spec entry
+2. Every form has validation rules AND UI error display documented
+3. Every E2E test page is in Frontend UI Behaviors
+4. Every error response has a corresponding UI behavior
+5. Mobile behavior documented separately from desktop
+6. Feature flags documented with both states
+7. Screenshot subjects enumerated individually

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -53,6 +53,7 @@
         "LintNukeVerify",
         "LintServerFix",
         "LintServerVerify",
+        "LintSpecVerify",
         "PathsCleanDirectories",
         "PathsShowWorktreeInfo",
         "RunLocalClient",

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -69,6 +69,10 @@
         "TestE2eFeed",
         "TestE2eMobile",
         "TestE2eMultitenancy",
+        "TestEvals",
+        "TestEvalsCoverage",
+        "TestEvalsGenerate",
+        "TestEvalsMasterList",
         "TestServer"
       ]
     },

--- a/Docs/evals.md
+++ b/Docs/evals.md
@@ -242,11 +242,49 @@ The coverage score: `(covered * 1.0 + weak * 0.5) / total * 100`
 
 `TestEvalsCoverage` **fails** if any master list entries are missing — this is a hard gate, not a soft score. If the generator can't produce expectations that cover what the hand-written tests cover, the generator (or the spec) needs to be improved.
 
+## Spec Quality
+
+The eval system revealed that **spec completeness is the bottleneck** for expectation generation. An API-only spec scored 33.9/100 on coverage; adding frontend UI behaviors to the spec raised it to 98.7/100 — without changing any tests or eval logic.
+
+### Spec linter
+
+`LintSpecVerify` checks structural completeness of `SPEC-REFERENCE.md` — no LLM call, runs in <1 second. It verifies:
+
+- Required top-level sections (Overview, Endpoints, Data Models, Business Rules, Frontend UI Behaviors)
+- Frontend subsections (Navigation, Route Guards, Mobile, Screenshots)
+- Dual-perspective coverage: frontend redirect behaviors (not just API 401s), UI error display (not just status codes), pagination UI (not just API limit/offset)
+
+```bash
+# Standalone
+./scripts/evals/lint-spec.sh
+
+# Via Nuke (also runs as part of LintAllVerify)
+./build.sh LintSpecVerify --agent
+```
+
+### Spec writing rules
+
+`.claude/rules/spec-writing.md` is auto-loaded when editing `SPEC-REFERENCE.md`. It contains the checklist of what a complete spec must cover, derived from the coverage gaps the eval system found.
+
+Key patterns that cause coverage gaps if missing:
+- **Route guards vs API 401s** — "browser redirects to /login" is distinct from "API returns 401"
+- **Error display vs error response** — "user sees error message" is distinct from "API returns 400"
+- **Mobile as a separate section** — responsive behavior is not implied by desktop
+- **Screenshots enumerated individually** — "visual regression tests" is too vague
+- **Each validation scenario is separate** — duplicate email vs duplicate username are different test cases
+
+### Spec generation eval prompt
+
+`scripts/evals/generate-spec.prompt.md` contains a prompt for generating a complete spec from codebase access. Can be used as a standalone eval: delete the spec, regenerate from the prompt, then score with `TestEvalsCoverage`. The 98.7 score becomes the target to beat.
+
 ## Usage
 
 ### Via Nuke targets (recommended)
 
 ```bash
+# Lint the spec for structural completeness (fast, no LLM)
+./build.sh LintSpecVerify --agent
+
 # Generate expectations from spec (once, or when spec changes)
 ./build.sh TestEvalsGenerate --agent
 
@@ -262,8 +300,9 @@ The coverage score: `(covered * 1.0 + weak * 0.5) / total * 100`
 
 | Target | What it does | When to run |
 |--------|-------------|-------------|
+| `LintSpecVerify` | Structural completeness check on `SPEC-REFERENCE.md` (no LLM) | Before generating expectations, or as part of `LintAllVerify` |
 | `TestEvalsGenerate` | Reads `SPEC-REFERENCE.md`, calls Claude to produce `expectations.json` | Once, or when spec changes |
-| `TestEvalsMasterList` | Reads existing test code, calls Claude to produce `master-list.json` | Once, or when E2E tests change |
+| `TestEvalsMasterList` | Parses `[TestCoverage]` attributes from test source into `master-list.json` (no LLM) | Once, or when E2E tests change |
 | `TestEvalsCoverage` | Asserts `expectations.json ⊇ master-list.json` — fails if gaps exist | After generating both files |
 | `TestEvals` | Runs E2E with tracing, extracts traces, grades each against expectations | Full eval run |
 
@@ -278,6 +317,9 @@ Output goes to `Reports/Test/Evals/`:
 ### Via shell scripts (for debugging or custom pipelines)
 
 ```bash
+# Lint the spec
+./scripts/evals/lint-spec.sh
+
 # Generate expectations
 ./scripts/evals/generate-expectations.sh \
   --spec SPEC-REFERENCE.md \

--- a/Docs/evals.md
+++ b/Docs/evals.md
@@ -1,0 +1,363 @@
+# Trace-Based Eval System
+
+## Problem
+
+Tests verify that code behaves correctly. But what verifies that the tests themselves are good?
+
+A test can pass mechanically while proving almost nothing — checking that a page loaded without verifying its content, asserting an element is visible without confirming it's the right element, or covering a happy path without exercising the actual business logic. When tests are generated (by a model or by a human in a hurry), this problem gets worse: the generator has an incentive to produce tests that pass, not tests that catch bugs.
+
+The trace eval system adds an independent observational layer: a model watches what actually happened during each test (via Playwright traces) and judges whether the test genuinely demonstrated what it claims.
+
+## Architecture
+
+```
+                             SPEC-REFERENCE.md
+                                    │
+                            ┌───────▼────────┐
+                            │  generate-      │
+                            │  expectations   │  (Model A — one-time)
+                            └───────┬────────┘
+                                    │
+                             expectations.json
+                              ╱            ╲
+                  ┌──────────╱──────────┐   ╲
+                  │     Layer 2:        │    ╲
+                  │   Trace Grading     │     ╲
+                  │                     │      ╲
+               trace₁   trace₂   trace₃   ┌───▼──────────────┐
+                 │         │        │      │    Layer 3:       │
+              extract   extract  extract   │ Coverage Check    │
+                 │         │        │      │                   │
+               grade     grade    grade    │ master-list.json  │
+              (Model B)           │        │ (from existing    │
+                 │         │        │      │  test suite)      │
+               PASS      WEAK    FAIL     │        ↕           │
+                 │         │        │      │ expectations.json │
+                 └─────────┼────────┘      │  ⊇ master-list?  │
+                           │               └───────┬──────────┘
+                   eval-report.json                │
+                                          coverage-report.json
+```
+
+There are three layers of evaluation, each independent:
+
+**Layer 1 — Mechanical test execution.** Playwright tests run against the app. Each test either passes or fails based on its coded assertions. This is the traditional test layer.
+
+**Layer 2 — Trace grading.** An independent model (the "judge") examines the Playwright trace of each test run and decides whether the trace evidence actually demonstrates what the test claims. The judge sees actions, network requests, DOM snapshots, console messages, and screenshots — raw observational data, not assertion logic.
+
+**Layer 3 — Coverage completeness.** The existing hand-written test suite is reverse-engineered into a master list of known behaviors that should be tested. The generated expectations (from the spec) are then checked against this master list. If the generator missed something the hand-written tests cover, it's a gap. This ensures the spec-to-expectations generator doesn't silently drop coverage.
+
+The key property: **the judge cannot be fooled by weak assertions.** A test that checks `toBeVisible` on a generic element gets graded WEAK even if it passed mechanically, because the judge sees that the DOM was never inspected for the specific content the spec requires.
+
+## The Recursion Problem
+
+> We need tests to test the code. But we also need evals to test the tests.
+
+This sounds like an infinite regress, but the eval layer breaks it because it's grounded differently:
+
+| Layer | Grounded in | Can be wrong because |
+|-------|------------|---------------------|
+| Code | Implementation logic | Bugs |
+| Tests | Assertion logic | Weak/wrong assertions |
+| Trace evals (L2) | Raw observation (DOM, network, screenshots) | Model misreads evidence |
+| Coverage evals (L3) | Existing hand-written tests | Master list extraction misses a test, or semantic matching is wrong |
+
+The eval layer's failure mode (model misreads a screenshot or misunderstands the spec) is independent of the test layer's failure mode (wrong assertion logic). This means the two layers catch different classes of bugs. A test with correct assertions but broken code fails at Layer 1. A test with weak assertions but working code passes Layer 1 but fails Layer 2.
+
+## Components
+
+### expectations.json
+
+Generated from `SPEC-REFERENCE.md` by `generate-expectations.sh`. Each expectation describes one testable behavior:
+
+```json
+{
+  "id": "auth-001",
+  "name": "UserCanSignIn_WithExistingCredentials",
+  "category": "happy_path",
+  "spec_section": "Authentication > Login Flow",
+  "feature_area": "auth",
+  "expected_behavior": "User navigates to /login, fills email and password, clicks Sign in. App authenticates and redirects to home page showing the user is logged in.",
+  "key_assertions": [
+    "POST /api/identity/login returns 200 with accessToken",
+    "Settings link becomes visible in sidebar (indicates authenticated state)",
+    "User's email/username is displayed in the navigation"
+  ],
+  "ui_indicators": [
+    "Login form has Email and Password fields",
+    "After login, sidebar shows Settings link",
+    "User profile link shows the email address"
+  ],
+  "network_indicators": [
+    "POST /api/identity/login?useCookies=false -> 200",
+    "GET /api/user -> 200"
+  ]
+}
+```
+
+The expectation is the "ground truth" — what a correct test for this behavior must demonstrate. It's derived from the spec, not from the tests themselves.
+
+### Trace Extraction
+
+Playwright traces are ZIP files containing NDJSON (newline-delimited JSON):
+
+| File in ZIP | Contents |
+|-------------|----------|
+| `trace.trace` | Action events (goto, click, fill, expect), DOM snapshots, console messages, screenshots |
+| `trace.network` | HTTP request/response events with status codes and headers |
+| `resources/` | Binary blobs — screenshot JPEGs, DOM snapshot HTML, response bodies (keyed by SHA1) |
+
+`extract-trace.sh` parses these into a single JSON structure:
+
+```json
+{
+  "actions": [
+    { "method": "page.goto", "params": { "url": "/login" }, "passed": true },
+    { "method": "locator.fill", "params": { "selector": "getByPlaceholder('Email')", "value": "user@test.com" }, "passed": true },
+    { "method": "expect(locator).toBeVisible", "params": { "selector": "getByRole('link', { name: 'Settings' })" }, "passed": true }
+  ],
+  "network": [
+    { "method": "POST", "url": "/api/identity/login?useCookies=false", "status": 200 },
+    { "method": "GET", "url": "/api/user", "status": 200 }
+  ],
+  "dom_snapshots": [
+    { "visible_text": "Settings Users testuser@test.com Dashboard Welcome" }
+  ],
+  "console_messages": [],
+  "summary": { "total_actions": 6, "failed_actions": 0 }
+}
+```
+
+### Grading
+
+`grade-trace.sh` sends the extracted trace + expectation to a model with a grading prompt. The model acts as an independent judge, examining the evidence and returning a structured verdict:
+
+```json
+{
+  "verdict": "WEAK",
+  "confidence": 0.82,
+  "demonstrated": ["POST /api/identity/login returns 200"],
+  "not_demonstrated": [
+    "Settings link visible in sidebar",
+    "User's email displayed in navigation"
+  ],
+  "concerns": [
+    "Only asserts URL redirect, never verifies authenticated UI state",
+    "No DOM snapshots captured to verify UI indicators"
+  ],
+  "evidence": {
+    "actions_match": true,
+    "network_match": true,
+    "ui_match": false,
+    "no_errors": true
+  },
+  "reasoning": "The trace shows correct login flow and successful API calls, but the test only asserts a URL redirect and never verifies the two most important indicators..."
+}
+```
+
+### Verdicts
+
+| Verdict | Meaning | Score |
+|---------|---------|-------|
+| **PASS** | Trace demonstrates ALL key assertions. Actions, network, and UI evidence all confirm the feature works and the test verifies it. | 1.0 |
+| **WEAK** | Feature appears to work (network succeeds, no errors) but the test doesn't fully verify it. A broken app could also pass this test. | 0.4 |
+| **FAIL** | Trace does not demonstrate expected behavior. Errors, wrong status codes, timeouts, or missing actions. | 0.0 |
+
+The WEAK verdict is the most valuable signal — it catches tests that provide false confidence.
+
+### Composite Score
+
+```
+score = (PASS_count * 1.0 + WEAK_count * 0.4) / graded_count * 100
+```
+
+The `eval-report.json` also tracks:
+- Per-verdict counts and pass rate
+- Feature area coverage (how many spec sections have at least one PASS)
+- A concerns list aggregating all WEAK/FAIL issues for targeted improvement
+
+## Layer 3: Coverage Completeness
+
+Layer 2 answers "are the tests good?" Layer 3 answers "are there enough tests?"
+
+The existing hand-written E2E test suite represents known-good coverage — behaviors that a human decided were important enough to test. When generating expectations from the spec, the generator might miss some of these. Layer 3 catches that.
+
+### Master list extraction
+
+Every `[Fact]` test method is annotated with a `[TestCoverage]` attribute directly in the source code:
+
+```csharp
+[Fact]
+[TestCoverage(
+    Id = "auth-happy-001",
+    FeatureArea = "auth",
+    Behavior = "User can log in with valid credentials and see authenticated UI state",
+    Verifies = ["Settings link visible in sidebar", "User profile link shows email"]
+)]
+public async Task UserCanSignIn_WithExistingCredentials()
+```
+
+The `TestEvalsMasterList` Nuke target parses these attributes from the source files (regex over `.cs` files — no assembly loading, no LLM call) and produces `master-list.json`:
+
+```json
+{
+  "test_count": 73,
+  "by_feature": { "auth": 8, "articles": 7, "editor": 10, "feed": 11, ... },
+  "tests": [
+    {
+      "id": "auth-happy-001",
+      "test_method": "UserCanSignIn_WithExistingCredentials",
+      "feature_area": "auth",
+      "category": "happy_path",
+      "behavior": "User can log in with valid credentials and see authenticated UI state",
+      "verifies": ["Settings link visible in sidebar", "User profile link shows email"]
+    }
+  ]
+}
+```
+
+This is deterministic, fast (<1 second), and requires no LLM call.
+
+A Roslyn analyzer (E2E008) enforces that every `[Fact]` method has a `[TestCoverage]` attribute — you can't add a test without documenting what it proves. The master list is a checked-in artifact, regenerated whenever tests change.
+
+### Coverage comparison
+
+`eval-coverage.sh` takes both files and uses a model to semantically match each master list entry against the generated expectations:
+
+```json
+{
+  "master_id": "users-happy-005",
+  "master_method": "DeactivatedUserCannotLogin",
+  "match_status": "missing",
+  "match_reasoning": "No expectation covers the specific behavior of deactivated users being unable to log in. The auth expectations cover login success/failure but not account lockout."
+}
+```
+
+Match statuses:
+- **covered** — an expectation exists that tests the same behavior with equivalent assertions
+- **weak** — an expectation exists in the same area but doesn't fully cover the specific behavior
+- **missing** — no expectation covers this behavior at all
+
+The coverage score: `(covered * 1.0 + weak * 0.5) / total * 100`
+
+`TestEvalsCoverage` **fails** if any master list entries are missing — this is a hard gate, not a soft score. If the generator can't produce expectations that cover what the hand-written tests cover, the generator (or the spec) needs to be improved.
+
+## Usage
+
+### Via Nuke targets (recommended)
+
+```bash
+# Generate expectations from spec (once, or when spec changes)
+./build.sh TestEvalsGenerate --agent
+
+# Extract master list from existing test suite (once, or when tests change)
+./build.sh TestEvalsMasterList --agent
+
+# Check that generated expectations cover all known tests (Layer 3)
+./build.sh TestEvalsCoverage --agent
+
+# Run E2E with tracing + grade traces (Layer 2)
+./build.sh TestEvals --agent
+```
+
+| Target | What it does | When to run |
+|--------|-------------|-------------|
+| `TestEvalsGenerate` | Reads `SPEC-REFERENCE.md`, calls Claude to produce `expectations.json` | Once, or when spec changes |
+| `TestEvalsMasterList` | Reads existing test code, calls Claude to produce `master-list.json` | Once, or when E2E tests change |
+| `TestEvalsCoverage` | Asserts `expectations.json ⊇ master-list.json` — fails if gaps exist | After generating both files |
+| `TestEvals` | Runs E2E with tracing, extracts traces, grades each against expectations | Full eval run |
+
+Output goes to `Reports/Test/Evals/`:
+- `expectations.json` — generated from spec (Layer 2 + 3 input)
+- `master-list.json` — extracted from existing tests (Layer 3 input)
+- `coverage-report.json` — Layer 3 results (gaps, weak coverage)
+- `Results/eval-report.json` — Layer 2 results (trace verdicts + composite score)
+- `Results/extracted/` — per-trace extracted JSON
+- `Results/verdicts/` — per-trace grading verdicts
+
+### Via shell scripts (for debugging or custom pipelines)
+
+```bash
+# Generate expectations
+./scripts/evals/generate-expectations.sh \
+  --spec SPEC-REFERENCE.md \
+  --output Reports/Test/Evals/expectations.json
+
+# Extract a single trace
+./scripts/evals/extract-trace.sh path/to/trace.zip > extracted.json
+
+# Grade a single trace
+./scripts/evals/grade-trace.sh extracted.json expectation.json
+
+# Run full pipeline on a directory of traces
+./scripts/evals/eval-traces.sh \
+  Reports/Test/e2e/Artifacts/ \
+  Reports/Test/Evals/expectations.json \
+  --output Reports/Test/Evals/Results/
+```
+
+## Controlling Tracing
+
+Tracing is controlled by the `PLAYWRIGHT_ALWAYS_TRACE` environment variable:
+
+| Value | Behavior | When to use |
+|-------|----------|-------------|
+| `false` (default) | Traces saved only for **failed** tests | Normal `TestE2e` runs |
+| `true` | Traces saved for **all** tests | `TestEvals` sets this automatically |
+
+This flows through the stack as:
+1. Nuke target sets `PLAYWRIGHT_ALWAYS_TRACE=true` in the process environment
+2. `docker-compose.yml` passes it to the playwright container via `${PLAYWRIGHT_ALWAYS_TRACE:-false}`
+3. `AppPageTest.StopTracingAsync()` checks the env var and saves traces accordingly
+
+Running `TestE2e` directly is unaffected — tracing stays failure-only.
+
+## Integration with the Autoresearch Harness
+
+In `score.sh`, the eval pipeline slots in after test execution:
+
+```
+1. Agent builds the app from spec                    (existing)
+2. Run all test suites                               (existing)
+3. Generate expectations from spec                   (new — Layer 2)
+4. Run E2E tests again with always-on tracing        (new — Layer 2)
+5. eval-traces.sh grades each trace                  (new — Layer 2)
+6. Composite score combines test results + eval      (modified)
+```
+
+The modified scoring formula:
+
+```
+if all tests pass:
+  base = 50
+  eval_bonus = floor(eval_score / 100 * 15)    # 0-15 for trace quality
+  alignment  = alignment_audit (0-15)           # reduced from 30
+  time_bonus = existing formula (0-20)
+  score = base + eval_bonus + alignment + time_bonus
+else:
+  score = floor(tests_passing / total_tests * 45)
+```
+
+This creates pressure not just to pass tests, but to pass them with strong assertions that the eval layer grades as PASS rather than WEAK.
+
+## Calibration
+
+Before trusting the eval system on generated tests, calibrate it against known-good and known-bad traces:
+
+```bash
+# Generate synthetic traces for all three scenarios
+./scripts/evals/create-test-trace.sh /tmp/calibration/ --scenario good
+./scripts/evals/create-test-trace.sh /tmp/calibration/ --scenario weak
+./scripts/evals/create-test-trace.sh /tmp/calibration/ --scenario bad
+
+# Grade each — verify: good→PASS, weak→WEAK, bad→FAIL
+./scripts/evals/eval-traces.sh /tmp/calibration/ expectations.json
+```
+
+Calibration results from initial testing:
+
+| Scenario | Expected | Actual | Confidence |
+|----------|----------|--------|------------|
+| Good (strong assertions) | PASS | PASS | 0.92 |
+| Weak (URL-only assertion) | WEAK | WEAK | 0.82 |
+| Bad (wrong password, 401) | FAIL | FAIL | 0.99 |

--- a/SPEC-REFERENCE.md
+++ b/SPEC-REFERENCE.md
@@ -1056,6 +1056,144 @@ interface CreateCommentRequest {
 
 ---
 
+## Frontend UI Behaviors
+
+> These behaviors are tested via E2E (Playwright) tests and describe how the frontend application
+> should behave from the user's perspective. They complement the API specification above.
+
+### Navigation & Layout
+
+- **Sidebar navigation:** Authenticated users see links for Dashboard, Home, Editor, Settings in the sidebar
+- **Admin navigation:** Users with ADMIN role see a "Users" link in the sidebar navigation; non-admin users do NOT see it
+- **Non-admin access to /users:** Non-admin users navigating directly to `/users` are redirected to a Forbidden page
+- **Forbidden page:** The 403 Forbidden page displays a message and includes a link to the home page
+- **Active nav highlighting:** The current page's sidebar link should be visually distinguished
+
+### Route Guards (Frontend Redirects)
+
+When an unauthenticated user navigates to a protected page, the frontend redirects to `/login`:
+
+| Protected Route | Redirect Target |
+|----------------|----------------|
+| `/editor` | `/login` |
+| `/settings` | `/login` |
+| `/dashboard` | `/login` |
+| `/profile/*` | `/login` |
+| `/article/*` | `/login` |
+
+This is distinct from the API returning 401 — the frontend route guard prevents the API call entirely. E2E tests must verify the browser URL changes to `/login`, not just that the API returns 401. Each protected route must have its own redirect test.
+
+### Mobile Responsive Behavior
+
+The app uses Carbon Design System's responsive layout. At mobile viewport (375×667):
+
+- **Sidebar hidden on load:** The sidebar navigation is not visible on initial page load
+- **Hamburger button visible:** A hamburger menu button is visible in the header
+- **Hamburger toggles sidebar:** Clicking the hamburger button opens the sidebar overlay
+- **Nav link closes sidebar:** Clicking a navigation link navigates to the target page AND closes the sidebar
+- **Unauthenticated mobile nav:** Unauthenticated users see Sign In and Sign Up links in the mobile sidebar
+- **Mobile screenshots:** Visual regression tests capture the mobile layout for Dashboard, sidebar open state, and other key pages
+
+### Dashboard Page
+
+- **URL:** `/dashboard` (authenticated only)
+- **Welcome message:** Displays a personalized welcome message when logged in (e.g., "Welcome, {username}")
+- **Feature flag banner:** When the `DashboardBanner` feature flag is enabled, a promotional banner is displayed
+- **Banner toggle:** When the `DashboardBanner` feature flag is disabled/toggled off, the banner disappears without page reload
+
+### Internationalization (i18n)
+
+- **Language switching:** Users can change the app language in Settings (e.g., English → Japanese)
+- **Translated UI elements:** After language change, the sidebar navigation, page titles, success messages, and dashboard welcome text are displayed in the selected language
+- **Persistence:** The selected language persists across page navigations within the session
+
+### Authentication UI Flows
+
+- **Sign out:** Users can sign out from the Settings page; after sign out, the user is redirected to the login page
+- **Login error display (wrong password):** When login fails due to incorrect password, the frontend must display a visible error message to the user. This is a UI behavior test — the API returns 401, but the frontend must catch it and render an error notification. The test must verify the error text is visible in the DOM, not just the API status code.
+- **Login error display (unregistered email):** When login fails due to an unregistered email, the frontend must display a visible error message. Same pattern: API returns 401, frontend renders error. Test must verify error text visibility in the DOM.
+- **Registration duplicate email:** Attempting to register with an already-taken email displays an error message in the UI (not just an API 400 — the error must be visible to the user). The error text contains "already been registered with that email".
+- **Registration duplicate username (via email):** Since username defaults to email, registering a second user with the same email as an existing user also produces a duplicate username. This is a SEPARATE test case from duplicate email — it verifies the error message is displayed when the resulting username (which equals the email) would collide. The error message contains "already been registered with that email".
+- **Post-registration navigation:** After first user registration (tenant signup), the user is redirected and the sidebar shows the "Users" nav item (since first user gets ADMIN role)
+- **Invite + login flow:** After an admin invites a user, the admin can sign out and the invited user can sign in via the login page
+
+### Admin User Management Page
+
+- **URL:** `/users` (requires ADMIN role)
+- **Navigation:** Admin users can navigate to the Users page from the sidebar menu
+- **User list:** Displays a table of all users in the current tenant with columns for username, email, roles, and status (active/deactivated)
+- **Pagination:** The users table supports pagination; pagination controls display the correct total count
+- **Profile link:** Clicking a user's profile link in the table navigates to that user's profile page
+
+#### User Deactivation
+
+- **Deactivate user:** Admin can deactivate a user; the status column updates to show "Deactivated"
+- **Deactivate + reactivate:** Admin can deactivate and then reactivate a user; status toggles accordingly
+- **Deactivated user cannot login:** A deactivated user attempting to log in is rejected
+- **Cannot deactivate self:** An admin cannot deactivate their own account (button disabled or action prevented)
+
+#### Role Management
+
+- **Edit roles modal:** Clicking an edit button on a user row opens a modal for editing roles
+- **Add admin role:** Admin can add the ADMIN role to a user via the edit roles modal
+- **Remove admin role:** Admin can remove the ADMIN role from a user
+- **Owner role read-only:** The OWNER role (first tenant user) is displayed as read-only and cannot be removed
+- **Cannot remove own admin role:** An admin cannot remove their own ADMIN role
+
+### Screenshots (Visual Regression)
+
+The following pages/states have visual regression screenshot tests. Each is a separate test case:
+
+- Users page with multiple users listed
+- Users page with pagination visible
+- Users page with a deactivated user visible
+- Edit roles modal in open state
+- Mobile viewport: Login page (375×667)
+- Mobile viewport: Register page (375×667)
+- Mobile viewport: Settings page (375×667)
+- Mobile viewport: Dashboard page (375×667)
+- Mobile viewport: Sidebar open state (375×667)
+- Article page with max-length content (title, description, body all at their maximum allowed lengths)
+- Home page showing Global Feed tab with at least one article preview visible
+
+### Home Page (Feed)
+
+- **Default tab for authenticated users:** "Your Feed" tab is selected by default when an authenticated user visits the home page
+- **Tags visible on individual article page:** When viewing a single article at `/article/{slug}`, the article's tags must be rendered visibly on the page (not just present in the API response — they must be in the DOM)
+- **Tags in article previews:** Tags appear in article preview cards on both Global Feed and Your Feed tabs (using `.tag-list` CSS class)
+- **Popular tags sidebar:** Tags from created articles appear in the "Popular Tags" sidebar section
+- **Tag filtering:** Clicking a tag in the Popular Tags sidebar filters articles to show only those with that tag
+- **Pagination with few articles:** Pagination controls are rendered even when the total article count is within a single page
+- **Global Feed pagination navigation:** On the Global Feed tab, clicking pagination page numbers navigates between pages — the displayed articles change and the active page indicator updates. This is a frontend UI navigation test, not an API pagination test.
+- **Your Feed pagination navigation:** On the Your Feed tab, pagination works identically — clicking page numbers navigates between pages of followed-user articles. This is distinct from the API `limit/offset` test; it verifies the UI pagination component works on the Your Feed tab specifically.
+
+### Editor Page Tag UI
+
+- **Add tag via Enter:** Typing a tag name and pressing Enter adds it; the tag appears as a chip/pill below the input
+- **Add tag via comma:** Typing a tag name followed by a comma adds it similarly
+- **Edit mode shows existing tags:** When editing an existing article, its current tags are displayed below the input
+- **Remove individual tag:** Each tag chip has a remove/close button; clicking it removes that tag
+- **Removed tag persists on save:** After removing a tag and clicking Publish, the article is saved without the removed tag
+- **Unsubmitted tag added on publish:** If text is in the tag input field when Publish Article is clicked, it is automatically added as a tag before submission
+- **Duplicate title error display:** When creating an article with a title that produces a duplicate slug, the frontend must display the error message to the user (not just receive a 400 from the API — the error must be visible in the DOM)
+
+### Profile Page
+
+- **View own profile:** Authenticated user can navigate to their own profile page and see their username, bio, and image
+- **Profile redirect when unauthenticated:** Unauthenticated users accessing a profile page are redirected to `/login`
+
+### Swagger / API Documentation
+
+- **URL:** `/swagger` (publicly accessible)
+- **API docs displayed:** The Swagger UI renders and displays the API documentation with endpoint listings
+
+### Multi-Tenancy (Frontend Behavior)
+
+- **User isolation:** Users registered in one tenant are not visible or accessible from another tenant
+- **Duplicate usernames across tenants:** Two users can have the same email/username if they are in different tenants (each tenant is isolated)
+
+---
+
 ## Implementation Status
 
 ### Already Built (in the starter template)

--- a/Task/Runner/Nuke/Build.Lint.cs
+++ b/Task/Runner/Nuke/Build.Lint.cs
@@ -158,7 +158,7 @@ public partial class Build
 
   internal Target LintAllVerify => _ => _
       .Description("Verify all C# code formatting & analyzers (no changes). Fails if issues found")
-      .DependsOn(LintClientVerify, LintServerVerify, LintNukeVerify, LintClaudeMdVerify, LintClaudeRulesVerify, LintApiClientVerify, LintAppSettingsVerify)
+      .DependsOn(LintClientVerify, LintServerVerify, LintNukeVerify, LintClaudeMdVerify, LintClaudeRulesVerify, LintApiClientVerify, LintAppSettingsVerify, LintSpecVerify)
       .Executes(() =>
       {
         var e2eTestProject = RootDirectory / "Test" / "e2e" / "E2eTests" / "E2eTests.csproj";
@@ -257,5 +257,34 @@ public partial class Build
         }
 
         Log.Information("✓ All {Count} rules files are within the {MaxLines}-line limit", files.Count, maxLines);
+      });
+
+  internal Target LintSpecVerify => _ => _
+      .Description("Verify SPEC-REFERENCE.md has all required sections for complete eval coverage")
+      .Executes(() =>
+      {
+        var specFile = RootDirectory / "SPEC-REFERENCE.md";
+        if (!specFile.FileExists())
+        {
+          throw new Exception($"Spec file not found: {specFile}");
+        }
+
+        var script = RootDirectory / "scripts" / "evals" / "lint-spec.sh";
+        if (!script.FileExists())
+        {
+          throw new Exception($"Lint script not found: {script}");
+        }
+
+        Log.Information("Linting spec: {File}", specFile);
+
+        var process = ProcessTasks.StartProcess(
+          "bash",
+          $"{script} --spec {specFile}",
+          workingDirectory: RootDirectory,
+          logOutput: true);
+
+        process.AssertZeroExitCode();
+
+        Log.Information("✓ Spec passes structural completeness checks");
       });
 }

--- a/Task/Runner/Nuke/Build.Paths.cs
+++ b/Task/Runner/Nuke/Build.Paths.cs
@@ -87,6 +87,12 @@ public partial class Build
 
   internal AbsolutePath ReportsTestE2eArtifactsDirectory => RootDirectory / "Reports" / "Test" / "e2e" / "Artifacts";
 
+  internal AbsolutePath ReportsTestEvalsDirectory => RootDirectory / "Reports" / "Test" / "Evals";
+
+  internal AbsolutePath ReportsTestEvalsExpectationsFile => ReportsTestEvalsDirectory / "expectations.json";
+
+  internal AbsolutePath ReportsTestEvalsResultsDirectory => ReportsTestEvalsDirectory / "Results";
+
   #endregion
 
   #region Logs
@@ -131,6 +137,9 @@ public partial class Build
       LogsTestE2eSerilogDirectory.CreateOrCleanDirectory();
       LogsTestServerSerilogDirectory.CreateOrCleanDirectory();
       LogsTestServerAuditDotNetDirectory.CreateOrCleanDirectory();
+
+      // Create Evals results directory (but NOT expectations — those are expensive to regenerate)
+      ReportsTestEvalsResultsDirectory.CreateOrCleanDirectory();
 
       Log.Information("✓ Directories cleaned and pre-created");
     });

--- a/Task/Runner/Nuke/Build.Test.cs
+++ b/Task/Runner/Nuke/Build.Test.cs
@@ -322,6 +322,361 @@ public partial class Build
     }
   }
 
+  internal Target TestEvalsGenerate => _ => _
+    .Description("Generate eval expectations from SPEC-REFERENCE.md using Claude")
+    .Executes(() =>
+    {
+      var specFile = RootDirectory / "SPEC-REFERENCE.md";
+      if (!specFile.FileExists())
+      {
+        throw new Exception($"Spec file not found: {specFile}. TestEvalsGenerate requires SPEC-REFERENCE.md at the repo root.");
+      }
+
+      ReportsTestEvalsDirectory.CreateDirectory();
+
+      var script = RootDirectory / "scripts" / "evals" / "generate-expectations.sh";
+      if (!script.FileExists())
+      {
+        throw new Exception($"Script not found: {script}");
+      }
+
+      Log.Information("Generating eval expectations from {SpecFile}", specFile);
+
+      var process = ProcessTasks.StartProcess(
+        "bash",
+        $"{script} --spec {specFile} --output {ReportsTestEvalsExpectationsFile}",
+        workingDirectory: RootDirectory,
+        logOutput: !Agent);
+      process.WaitForExit();
+
+      if (process.ExitCode != 0)
+      {
+        throw new Exception($"generate-expectations.sh failed with exit code {process.ExitCode}");
+      }
+
+      Log.Information("Expectations written to {File}", ReportsTestEvalsExpectationsFile);
+    });
+
+  internal Target TestEvalsMasterList => _ => _
+    .Description("Extract master test coverage list from [TestCoverage] attributes in E2E tests")
+    .Executes(() =>
+    {
+      var testsDir = RootDirectory / "Test" / "e2e" / "E2eTests" / "Tests";
+      if (!testsDir.DirectoryExists())
+      {
+        throw new Exception($"Tests directory not found: {testsDir}");
+      }
+
+      ReportsTestEvalsDirectory.CreateDirectory();
+      var masterListFile = ReportsTestEvalsDirectory / "master-list.json";
+
+      Log.Information("Extracting [TestCoverage] attributes from {TestsDir}", testsDir);
+
+      var tests = new List<Dictionary<string, object>>();
+      var testFiles = testsDir.GlobFiles("**/*.cs");
+
+      var attrPattern = new System.Text.RegularExpressions.Regex(
+        @"\[TestCoverage\(\s*" +
+        @"Id\s*=\s*""(?<id>[^""]+)""\s*,\s*" +
+        @"FeatureArea\s*=\s*""(?<area>[^""]+)""\s*,\s*" +
+        @"Behavior\s*=\s*""(?<behavior>[^""]+)""" +
+        @"(?:\s*,\s*Verifies\s*=\s*\[(?<verifies>[^\]]*)\])?" +
+        @"\s*\)\]",
+        System.Text.RegularExpressions.RegexOptions.Singleline);
+
+      var methodPattern = new System.Text.RegularExpressions.Regex(
+        @"public\s+async\s+Task\s+(?<name>\w+)\s*\(");
+
+      foreach (var file in testFiles)
+      {
+        var content = file.ReadAllText();
+        var relativePath = RootDirectory.GetRelativePathTo(file);
+
+        // Extract class namespace/name from file path
+        var pathParts = relativePath.ToString().Replace("\\", "/").Split('/');
+        var pageName = pathParts.Length >= 2 ? pathParts[^2] : "Unknown";
+        var fileName = file.NameWithoutExtension;
+        var category = fileName.ToLowerInvariant() switch
+        {
+          "happypath" => "happy_path",
+          "validation" => "validation",
+          "permissions" => "permissions",
+          "screenshots" => "screenshots",
+          _ => fileName.ToLowerInvariant(),
+        };
+
+        var attrMatches = attrPattern.Matches(content);
+        var methodMatches = methodPattern.Matches(content);
+
+        // Pair each [TestCoverage] with its following method name
+        foreach (System.Text.RegularExpressions.Match attrMatch in attrMatches)
+        {
+          var id = attrMatch.Groups["id"].Value;
+          var area = attrMatch.Groups["area"].Value;
+          var behavior = attrMatch.Groups["behavior"].Value;
+          var verifiesRaw = attrMatch.Groups["verifies"].Value;
+
+          // Parse Verifies array: ["item1", "item2"]
+          var verifies = new List<string>();
+          if (!string.IsNullOrWhiteSpace(verifiesRaw))
+          {
+            var verifyPattern = new System.Text.RegularExpressions.Regex(@"""([^""]+)""");
+            foreach (System.Text.RegularExpressions.Match v in verifyPattern.Matches(verifiesRaw))
+            {
+              verifies.Add(v.Groups[1].Value);
+            }
+          }
+
+          // Find the method name that follows this attribute
+          var methodName = "Unknown";
+          foreach (System.Text.RegularExpressions.Match methodMatch in methodMatches)
+          {
+            if (methodMatch.Index > attrMatch.Index)
+            {
+              methodName = methodMatch.Groups["name"].Value;
+              break;
+            }
+          }
+
+          tests.Add(new Dictionary<string, object>
+          {
+            ["id"] = id,
+            ["test_method"] = methodName,
+            ["file"] = relativePath.ToString(),
+            ["feature_area"] = area,
+            ["category"] = category,
+            ["behavior"] = behavior,
+            ["verifies"] = verifies,
+          });
+        }
+      }
+
+      // Build JSON output
+      var jsonOptions = new System.Text.Json.JsonSerializerOptions
+      {
+        WriteIndented = true,
+        PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.SnakeCaseLower,
+      };
+
+      var masterList = new Dictionary<string, object>
+      {
+        ["generated_at"] = DateTime.UtcNow.ToString("o"),
+        ["source"] = testsDir.ToString(),
+        ["test_count"] = tests.Count,
+        ["by_feature"] = tests.GroupBy(t => (string)t["feature_area"])
+          .ToDictionary(g => g.Key, g => g.Count()),
+        ["by_category"] = tests.GroupBy(t => (string)t["category"])
+          .ToDictionary(g => g.Key, g => g.Count()),
+        ["tests"] = tests,
+      };
+
+      var json = System.Text.Json.JsonSerializer.Serialize(masterList, jsonOptions);
+      masterListFile.WriteAllText(json);
+
+      Log.Information("Extracted {Count} test coverage entries to {File}", tests.Count, masterListFile);
+
+      if (tests.Count == 0)
+      {
+        throw new Exception(
+          "No [TestCoverage] attributes found. Ensure all [Fact] test methods have " +
+          "[TestCoverage] attributes (enforced by E2E008 analyzer).");
+      }
+    });
+
+  internal Target TestEvalsCoverage => _ => _
+    .Description("Assert generated expectations cover all tests in the master list")
+    .Executes(() =>
+    {
+      var masterListFile = ReportsTestEvalsDirectory / "master-list.json";
+      if (!masterListFile.FileExists())
+      {
+        throw new Exception(
+          $"Master list not found: {masterListFile}. " +
+          "Run ./build.sh TestEvalsMasterList first.");
+      }
+
+      if (!ReportsTestEvalsExpectationsFile.FileExists())
+      {
+        throw new Exception(
+          $"Expectations file not found: {ReportsTestEvalsExpectationsFile}. " +
+          "Run ./build.sh TestEvalsGenerate first.");
+      }
+
+      var script = RootDirectory / "scripts" / "evals" / "eval-coverage.sh";
+      if (!script.FileExists())
+      {
+        throw new Exception($"Script not found: {script}");
+      }
+
+      var coverageReportFile = ReportsTestEvalsDirectory / "coverage-report.json";
+
+      Log.Information("Comparing expectations against master list");
+
+      var process = ProcessTasks.StartProcess(
+        "bash",
+        $"{script} {masterListFile} {ReportsTestEvalsExpectationsFile} --output {coverageReportFile}",
+        workingDirectory: RootDirectory,
+        logOutput: true);
+      process.WaitForExit();
+
+      if (coverageReportFile.FileExists())
+      {
+        var reportContent = coverageReportFile.ReadAllText();
+        var doc = System.Text.Json.JsonDocument.Parse(reportContent);
+        var score = doc.RootElement.GetProperty("score").GetProperty("coverage").GetDouble();
+        var missing = doc.RootElement.GetProperty("summary").GetProperty("missing").GetInt32();
+
+        Log.Information("Coverage score: {Score}/100", score);
+
+        if (missing > 0)
+        {
+          Log.Error("{Missing} test cases from the master list are not covered by generated expectations", missing);
+          Log.Error("See {File} for details", coverageReportFile);
+        }
+      }
+
+      if (process.ExitCode != 0)
+      {
+        throw new Exception(
+          $"Coverage check failed — generated expectations do not fully cover the master test list. " +
+          $"See {coverageReportFile} for gaps.");
+      }
+
+      Log.Information("All master list tests are covered by generated expectations");
+    });
+
+  internal Target TestEvals => _ => _
+    .Description("Run E2E tests with tracing enabled, then grade traces against spec expectations")
+    .DependsOn(BuildServerPublish)
+    .DependsOn(InstallDotnetToolLiquidReports)
+    .DependsOn(PathsCleanDirectories)
+    .Executes(() =>
+    {
+      // Ensure expectations exist
+      if (!ReportsTestEvalsExpectationsFile.FileExists())
+      {
+        throw new Exception(
+          $"Expectations file not found: {ReportsTestEvalsExpectationsFile}. " +
+          "Run ./build.sh TestEvalsGenerate first to generate expectations from the spec.");
+      }
+
+      // Step 1: Run E2E tests with always-on tracing
+      Log.Information("Running E2E tests with PLAYWRIGHT_ALWAYS_TRACE=true");
+
+      var composeFiles = SkipPublish
+        ? "-f Test/e2e/docker-compose.yml -f Test/e2e/docker-compose.ci.yml"
+        : "-f Test/e2e/docker-compose.yml";
+      var upArgs = SkipPublish
+        ? $"compose {composeFiles} up --no-build --abort-on-container-exit"
+        : $"compose {composeFiles} up --build --abort-on-container-exit";
+      var downArgs = $"compose {composeFiles} down";
+
+      int exitCode = 0;
+      try
+      {
+        var envVars = new Dictionary<string, string>(GetWorktreeEnvVars())
+        {
+          ["DOCKER_BUILDKIT"] = "1",
+          ["PLAYWRIGHT_ALWAYS_TRACE"] = "true",
+        };
+
+        var process = ProcessTasks.StartProcess(
+          "docker",
+          upArgs,
+          workingDirectory: RootDirectory,
+          environmentVariables: envVars,
+          logOutput: !Agent);
+        process.WaitForExit();
+        exitCode = process.ExitCode;
+
+        var apiExitCode = GetServiceExitCode(composeFiles, "api");
+        if (apiExitCode > 0 && exitCode == 0)
+        {
+          Log.Error("API container crashed with exit code {ApiExitCode} but Docker Compose reported success", apiExitCode);
+          exitCode = apiExitCode;
+        }
+      }
+      finally
+      {
+        var downEnvVars = GetWorktreeEnvVars();
+        var downProcess = ProcessTasks.StartProcess(
+          "docker",
+          downArgs,
+          workingDirectory: RootDirectory,
+          environmentVariables: downEnvVars,
+          logOutput: !Agent);
+
+        // Generate test report while compose tears down
+        var reportFile = ReportsTestE2eArtifactsDirectory / "Report.md";
+        try
+        {
+          Liquid(
+            $"--inputs \"File=*.trx;Folder={ReportsTestE2eResultsDirectory}\" --output-file {reportFile} --title \"nuke {nameof(TestEvals)} E2E Results\"");
+
+          var reportSummaryFile = ReportsTestE2eArtifactsDirectory / "ReportSummary.md";
+          ExtractReportSummary(reportFile, reportSummaryFile);
+
+          if (Agent)
+          {
+            PrintReportSummary(reportSummaryFile);
+          }
+        }
+        catch (Exception ex)
+        {
+          Log.Warning("Failed to generate LiquidTestReport: {Message}", ex.Message);
+        }
+
+        downProcess.WaitForExit();
+      }
+
+      if (exitCode != 0)
+      {
+        Log.Warning("E2E tests exited with code {ExitCode} — continuing to grade available traces", exitCode);
+      }
+
+      // Step 2: Grade traces against expectations
+      var tracesDir = ReportsTestE2eArtifactsDirectory;
+      var traceFiles = tracesDir.GlobFiles("*_trace_*.zip");
+
+      if (traceFiles.Count == 0)
+      {
+        Log.Warning("No trace files found in {Dir}. Ensure PLAYWRIGHT_ALWAYS_TRACE is being passed through docker-compose.", tracesDir);
+        throw new Exception("No trace files produced — eval grading cannot proceed.");
+      }
+
+      Log.Information("Found {Count} trace files to grade", traceFiles.Count);
+
+      var evalScript = RootDirectory / "scripts" / "evals" / "eval-traces.sh";
+      if (!evalScript.FileExists())
+      {
+        throw new Exception($"Script not found: {evalScript}");
+      }
+
+      var evalProcess = ProcessTasks.StartProcess(
+        "bash",
+        $"{evalScript} {tracesDir} {ReportsTestEvalsExpectationsFile} --output {ReportsTestEvalsResultsDirectory}",
+        workingDirectory: RootDirectory,
+        logOutput: true);
+      evalProcess.WaitForExit();
+
+      // Read and display eval report
+      var evalReportFile = ReportsTestEvalsResultsDirectory / "eval-report.json";
+      if (evalReportFile.FileExists())
+      {
+        var reportContent = evalReportFile.ReadAllText();
+        var score = System.Text.Json.JsonDocument.Parse(reportContent)
+          .RootElement.GetProperty("score").GetProperty("composite").GetDouble();
+
+        Log.Information("Eval score: {Score}/100", score);
+        Log.Information("Full eval report: {File}", evalReportFile);
+      }
+
+      if (evalProcess.ExitCode != 0)
+      {
+        throw new Exception($"eval-traces.sh failed with exit code {evalProcess.ExitCode}");
+      }
+    });
+
   private int GetServiceExitCode(string composeFiles, string serviceName)
   {
     try

--- a/Test/e2e/E2eTests.Analyzers/RequireTestCoverageAttributeAnalyzer.cs
+++ b/Test/e2e/E2eTests.Analyzers/RequireTestCoverageAttributeAnalyzer.cs
@@ -1,0 +1,60 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class RequireTestCoverageAttributeAnalyzer : DiagnosticAnalyzer
+{
+  public const string DiagnosticId = "E2E008";
+
+  public static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+      DiagnosticId,
+      "[TestCoverage] attribute is required on all [Fact] test methods",
+      "Test method '{0}' is missing [TestCoverage] attribute. Add [TestCoverage(Id = \"...\", FeatureArea = \"...\", Behavior = \"...\")] to document what this test verifies.",
+      "Documentation",
+      DiagnosticSeverity.Error,
+      isEnabledByDefault: true,
+      description: "Every [Fact] test method must have a [TestCoverage] attribute describing what behavior it verifies. This enables programmatic extraction of the test coverage master list.");
+
+  public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+      ImmutableArray.Create(Rule);
+
+  public override void Initialize(AnalysisContext context)
+  {
+    context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+    context.EnableConcurrentExecution();
+    context.RegisterSyntaxNodeAction(AnalyzeMethod, SyntaxKind.MethodDeclaration);
+  }
+
+  private static void AnalyzeMethod(SyntaxNodeAnalysisContext context)
+  {
+    var method = (MethodDeclarationSyntax)context.Node;
+
+    var hasFact = false;
+    var hasTestCoverage = false;
+
+    foreach (var attributeList in method.AttributeLists)
+    {
+      foreach (var attribute in attributeList.Attributes)
+      {
+        var name = attribute.Name.ToString();
+        if (name is "Fact" or "FactAttribute")
+        {
+          hasFact = true;
+        }
+        else if (name is "TestCoverage" or "TestCoverageAttribute")
+        {
+          hasTestCoverage = true;
+        }
+      }
+    }
+
+    if (hasFact && !hasTestCoverage)
+    {
+      var diagnostic = Diagnostic.Create(Rule, method.Identifier.GetLocation(), method.Identifier.Text);
+      context.ReportDiagnostic(diagnostic);
+    }
+  }
+}

--- a/Test/e2e/E2eTests/AppPageTest.cs
+++ b/Test/e2e/E2eTests/AppPageTest.cs
@@ -180,11 +180,14 @@ public abstract class AppPageTest : PageTest, IClassFixture<ApiFixture>
   /// </summary>
   private async Task StopTracingAsync()
   {
-    // Check if the test failed - only save trace for failed tests
+    // Check if tracing should always be saved (for eval grading)
+    var alwaysTrace = Environment.GetEnvironmentVariable("PLAYWRIGHT_ALWAYS_TRACE") == "true";
+
+    // Save trace for failed tests, or all tests when always-trace is enabled
     var testState = TestContext.Current.TestState;
     var testFailed = testState?.Result == TestResult.Failed;
 
-    if (testFailed)
+    if (testFailed || alwaysTrace)
     {
       if (!Directory.Exists(Constants.ReportsTestE2eArtifacts))
       {

--- a/Test/e2e/E2eTests/TestCoverageAttribute.cs
+++ b/Test/e2e/E2eTests/TestCoverageAttribute.cs
@@ -1,0 +1,13 @@
+namespace E2eTests;
+
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public sealed class TestCoverageAttribute : Attribute
+{
+  public required string Id { get; init; }
+
+  public required string FeatureArea { get; init; }
+
+  public required string Behavior { get; init; }
+
+  public string[] Verifies { get; init; } = [];
+}

--- a/Test/e2e/E2eTests/Tests/ArticlePage/HappyPath.cs
+++ b/Test/e2e/E2eTests/Tests/ArticlePage/HappyPath.cs
@@ -10,6 +10,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "article-happy-001",
+    FeatureArea = "articles",
+    Behavior = "Tags assigned to an article are displayed on the article detail page",
+    Verifies = ["both tags are visible on the article page"])]
   public async Task Tags_AreVisibleOnIndividualArticlePage()
   {
     // Arrange
@@ -29,6 +34,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "article-happy-002",
+    FeatureArea = "articles",
+    Behavior = "Author can delete their own article and it disappears from the global feed",
+    Verifies = ["article is no longer visible in global feed after deletion"])]
   public async Task UserCanDeleteOwnArticle()
   {
     // Arrange - create user and article via API
@@ -50,6 +60,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "article-happy-003",
+    FeatureArea = "articles",
+    Behavior = "User can favorite and then unfavorite another user's article",
+    Verifies = ["favorite button toggles to unfavorite", "unfavorite button toggles back"])]
   public async Task UserCanFavoriteAndUnfavoriteArticle()
   {
     // Arrange - create two users in the same tenant
@@ -70,6 +85,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "article-happy-004",
+    FeatureArea = "articles",
+    Behavior = "Authenticated user can add a comment to an article",
+    Verifies = ["comment is successfully posted via the article page"])]
   public async Task UserCanAddCommentToArticle()
   {
     // Arrange
@@ -87,6 +107,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "article-happy-005",
+    FeatureArea = "articles",
+    Behavior = "User can delete their own comment on an article",
+    Verifies = ["comment is removed from the article page after deletion"])]
   public async Task UserCanDeleteOwnComment()
   {
     // Arrange

--- a/Test/e2e/E2eTests/Tests/ArticlePage/Permissions.cs
+++ b/Test/e2e/E2eTests/Tests/ArticlePage/Permissions.cs
@@ -10,6 +10,11 @@ public class Permissions : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "article-permissions-001",
+    FeatureArea = "articles",
+    Behavior = "Unauthenticated user is redirected to the login page when accessing an article",
+    Verifies = ["URL changes to /login"])]
   public async Task UnauthenticatedUser_RedirectsToLogin_WhenAccessingArticlePage()
   {
     // Arrange

--- a/Test/e2e/E2eTests/Tests/ArticlePage/Screenshots.cs
+++ b/Test/e2e/E2eTests/Tests/ArticlePage/Screenshots.cs
@@ -10,6 +10,11 @@ public class Screenshots : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "article-screenshots-001",
+    FeatureArea = "articles",
+    Behavior = "Article page renders correctly with max-length content including title, body, and comment",
+    Verifies = ["article title is visible", "screenshot width does not exceed viewport width", "URL contains the article slug"])]
   public async Task ArticlePageWithMaxLengthContent()
   {
     // Arrange - create user with max-length fields

--- a/Test/e2e/E2eTests/Tests/DashboardPage/HappyPath.cs
+++ b/Test/e2e/E2eTests/Tests/DashboardPage/HappyPath.cs
@@ -10,6 +10,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "dashboard-happy-001",
+    FeatureArea = "dashboard",
+    Behavior = "Dashboard shows welcome message when user is logged in",
+    Verifies = ["Welcome heading is visible", "Welcome heading contains 'Welcome'"])]
   public async Task Dashboard_ShowsWelcomeMessage_WhenLoggedIn()
   {
     // Arrange
@@ -24,6 +29,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "dashboard-happy-002",
+    FeatureArea = "dashboard",
+    Behavior = "Dashboard shows feature banner when DashboardBanner flag is enabled",
+    Verifies = ["Feature banner is visible"])]
   public async Task Dashboard_ShowsBanner_WhenFeatureFlagEnabled()
   {
     // Arrange — E2E runs with Development config where all flags are enabled
@@ -37,6 +47,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "dashboard-happy-003",
+    FeatureArea = "dashboard",
+    Behavior = "Dashboard banner disappears when feature flag is toggled off and reappears when toggled on",
+    Verifies = ["Banner visible initially", "Banner disappears after flag disabled", "Banner reappears after flag re-enabled"])]
   public async Task Dashboard_BannerDisappears_WhenFeatureFlagToggledOff()
   {
     // Arrange — login and verify banner is visible

--- a/Test/e2e/E2eTests/Tests/EditorPage/HappyPath.cs
+++ b/Test/e2e/E2eTests/Tests/EditorPage/HappyPath.cs
@@ -10,6 +10,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "editor-happy-001",
+    FeatureArea = "editor",
+    Behavior = "User can create a new article with tags and view it on the article page",
+    Verifies = ["article title is displayed on article page", "author matches the logged-in user"])]
   public async Task UserCanCreateArticle_AndViewArticle()
   {
     // Arrange
@@ -34,6 +39,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "editor-happy-002",
+    FeatureArea = "editor",
+    Behavior = "User can create an article with multiple tags and see them on the article page",
+    Verifies = ["both tags are visible on the published article"])]
   public async Task UserCanCreateArticleWithTags_AndViewTagsOnArticle()
   {
     // Arrange
@@ -56,6 +66,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "editor-happy-003",
+    FeatureArea = "editor",
+    Behavior = "Pressing Enter in the tag input adds the tag below the input field",
+    Verifies = ["tag chip is visible below the tag input"])]
   public async Task TagsAppearBelowInput_WhenAddedViaEnter()
   {
     // Arrange
@@ -74,6 +89,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "editor-happy-004",
+    FeatureArea = "editor",
+    Behavior = "Typing a comma in the tag input adds the tag below the input field",
+    Verifies = ["tag chip is visible below the tag input"])]
   public async Task TagsAppearBelowInput_WhenAddedViaComma()
   {
     // Arrange
@@ -92,6 +112,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "editor-happy-005",
+    FeatureArea = "editor",
+    Behavior = "Existing tags are pre-populated when editing an article",
+    Verifies = ["tag1 is visible in the editor", "tag2 is visible in the editor"])]
   public async Task ExistingTagsDisplayed_WhenEditingArticle()
   {
     // Arrange
@@ -111,6 +136,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "editor-happy-006",
+    FeatureArea = "editor",
+    Behavior = "Individual tags can be removed from the editor without affecting other tags",
+    Verifies = ["removed tag is no longer visible", "remaining tag is still visible"])]
   public async Task TagsCanBeIndividuallyRemoved()
   {
     // Arrange
@@ -135,6 +165,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "editor-happy-007",
+    FeatureArea = "editor",
+    Behavior = "Removing a tag in the editor and saving persists the removal on the article page",
+    Verifies = ["removed tag is not visible on the article page", "remaining tag is still visible on the article page"])]
   public async Task RemovedTagIsPersistedAfterSave()
   {
     // Arrange
@@ -159,6 +194,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "editor-happy-008",
+    FeatureArea = "editor",
+    Behavior = "Tag text left in the input field without pressing Enter is automatically added when publishing",
+    Verifies = ["pending tag appears on the published article page"])]
   public async Task UnsubmittedTagInInputIsAddedOnPublish()
   {
     // Arrange
@@ -181,6 +221,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "editor-happy-009",
+    FeatureArea = "editor",
+    Behavior = "User can edit their own article's title and see the updated title on the article page",
+    Verifies = ["updated article title is displayed on the article page"])]
   public async Task UserCanEditOwnArticle()
   {
     // Arrange

--- a/Test/e2e/E2eTests/Tests/EditorPage/Validation.cs
+++ b/Test/e2e/E2eTests/Tests/EditorPage/Validation.cs
@@ -10,6 +10,11 @@ public class Validation : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "editor-validation-001",
+    FeatureArea = "editor",
+    Behavior = "Creating an article with a duplicate title displays a validation error",
+    Verifies = ["error message contains 'has already been taken'"])]
   public async Task CreateArticle_WithDuplicateTitle_DisplaysErrorMessage()
   {
     // Arrange

--- a/Test/e2e/E2eTests/Tests/HomePage/HappyPath.cs
+++ b/Test/e2e/E2eTests/Tests/HomePage/HappyPath.cs
@@ -12,6 +12,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "home-happy-001",
+    FeatureArea = "feed",
+    Behavior = "A newly created article appears in the global feed and can be clicked to view",
+    Verifies = ["article title is visible in global feed", "clicking article navigates to article page with correct title"])]
   public async Task CreatedArticle_AppearsInGlobalFeed()
   {
     // Arrange - create user and article via API
@@ -34,6 +39,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "home-happy-002",
+    FeatureArea = "feed",
+    Behavior = "Your Feed tab is selected by default for authenticated users on the home page",
+    Verifies = ["Your Feed tab is the active/selected tab"])]
   public async Task YourFeed_IsSelectedByDefaultForAuthenticatedUser()
   {
     // Arrange - create user and article via API
@@ -50,6 +60,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "home-happy-003",
+    FeatureArea = "feed",
+    Behavior = "Global feed pagination displays correctly and navigates between pages",
+    Verifies = ["initial page shows 20 articles", "pagination controls are visible", "navigating forward and back returns to first page with 20 articles", "backward button is disabled on first page"])]
   public async Task GlobalFeed_DisplaysPaginationAndNavigatesCorrectly()
   {
     // Arrange - create user and articles via API
@@ -77,6 +92,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "home-happy-004",
+    FeatureArea = "feed",
+    Behavior = "Your Feed shows articles from followed users within the same tenant",
+    Verifies = ["followed user's article is visible in Your Feed"])]
   public async Task YourFeed_ShowsArticlesFromFollowedUsers()
   {
     // Arrange - create two users IN THE SAME TENANT, article, and follow relationship via API
@@ -99,6 +119,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "home-happy-005",
+    FeatureArea = "feed",
+    Behavior = "Article tags appear in the article preview card on the global feed",
+    Verifies = ["both tags are visible in the article preview"])]
   public async Task Tags_AppearInArticlePreview_OnGlobalFeed()
   {
     // Arrange
@@ -119,6 +144,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "home-happy-006",
+    FeatureArea = "feed",
+    Behavior = "Article tags appear in the article preview card on Your Feed",
+    Verifies = ["both tags are visible in the article preview on Your Feed"])]
   public async Task Tags_AppearInArticlePreview_OnYourFeed()
   {
     // Arrange
@@ -142,6 +172,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "home-happy-007",
+    FeatureArea = "feed",
+    Behavior = "Tags from created articles appear in the sidebar popular tags section",
+    Verifies = ["tag is visible in the sidebar"])]
   public async Task CreatedArticleTags_AppearInSidebar_PopularTags()
   {
     // Arrange
@@ -158,6 +193,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "home-happy-008",
+    FeatureArea = "feed",
+    Behavior = "Clicking a sidebar tag filters the feed to show only articles with that tag",
+    Verifies = ["tag filter tab is visible", "article with the tag is visible in filtered results"])]
   public async Task UserCanFilterArticlesByTag()
   {
     // Arrange - create user and article with tag via API
@@ -180,6 +220,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "home-happy-009",
+    FeatureArea = "feed",
+    Behavior = "Global feed shows pagination even with fewer articles than one full page",
+    Verifies = ["articles are loaded", "pagination controls are visible"])]
   public async Task GlobalFeed_ShowsPaginationWithFewArticles()
   {
     // Arrange - create user and few articles via API
@@ -200,6 +245,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "home-happy-010",
+    FeatureArea = "feed",
+    Behavior = "Your Feed pagination displays correctly and navigates between pages",
+    Verifies = ["first page shows 20 articles", "pagination controls are visible", "last page shows remaining 10 articles", "navigating back shows 20 articles again"])]
   public async Task YourFeed_DisplaysPaginationAndNavigatesCorrectly()
   {
     // Arrange

--- a/Test/e2e/E2eTests/Tests/HomePage/Screenshots.cs
+++ b/Test/e2e/E2eTests/Tests/HomePage/Screenshots.cs
@@ -10,6 +10,11 @@ public class Screenshots : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "home-screenshots-001",
+    FeatureArea = "feed",
+    Behavior = "Home page global feed renders correctly with max-length article content and favorite count",
+    Verifies = ["article preview is visible in global feed", "screenshot width does not exceed viewport width", "URL is the home page"])]
   public async Task HomePageGlobalFeedWithArticle()
   {
     // Arrange - create user with max-length fields

--- a/Test/e2e/E2eTests/Tests/LoginPage/HappyPath.cs
+++ b/Test/e2e/E2eTests/Tests/LoginPage/HappyPath.cs
@@ -10,6 +10,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "auth-happy-001",
+    FeatureArea = "auth",
+    Behavior = "User can log in with valid credentials and see authenticated UI state",
+    Verifies = ["User profile link shows email after login"])]
   public async Task UserCanSignIn_WithExistingCredentials()
   {
     // Arrange

--- a/Test/e2e/E2eTests/Tests/LoginPage/Permissions.cs
+++ b/Test/e2e/E2eTests/Tests/LoginPage/Permissions.cs
@@ -1,4 +1,4 @@
-﻿namespace E2eTests.Tests.LoginPage;
+namespace E2eTests.Tests.LoginPage;
 
 /// <summary>
 /// Permission tests for the Login page (/login).
@@ -10,6 +10,11 @@ public class Permissions : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "auth-permissions-001",
+    FeatureArea = "auth",
+    Behavior = "Unauthenticated user accessing editor is redirected to login",
+    Verifies = ["URL changes to /login"])]
   public async Task EditorPage_RedirectToLogin_WhenNotAuthenticated()
   {
     // Arrange
@@ -20,6 +25,11 @@ public class Permissions : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "auth-permissions-002",
+    FeatureArea = "auth",
+    Behavior = "Unauthenticated user accessing settings is redirected to login",
+    Verifies = ["URL changes to /login"])]
   public async Task SettingsPage_RedirectToLogin_WhenNotAuthenticated()
   {
     // Arrange

--- a/Test/e2e/E2eTests/Tests/LoginPage/Validation.cs
+++ b/Test/e2e/E2eTests/Tests/LoginPage/Validation.cs
@@ -10,6 +10,11 @@ public class Validation : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "auth-validation-001",
+    FeatureArea = "auth",
+    Behavior = "Login with unregistered email shows error message",
+    Verifies = ["Error message contains 'Invalid email or password'"])]
   public async Task Login_WithUnregisteredEmail_DisplaysErrorMessage()
   {
     // Arrange
@@ -27,6 +32,11 @@ public class Validation : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "auth-validation-002",
+    FeatureArea = "auth",
+    Behavior = "Login with incorrect password shows error message",
+    Verifies = ["Error message contains 'Invalid email or password'"])]
   public async Task Login_WithIncorrectPassword_DisplaysErrorMessage()
   {
     // Arrange

--- a/Test/e2e/E2eTests/Tests/Mobile/Navigation.cs
+++ b/Test/e2e/E2eTests/Tests/Mobile/Navigation.cs
@@ -9,6 +9,11 @@ public class Navigation : MobileAppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "mobile-happy-001",
+    FeatureArea = "mobile",
+    Behavior = "Sidebar is hidden by default on mobile viewport",
+    Verifies = ["SideNav is not visible"])]
   public async Task SidebarIsHiddenOnPageLoad()
   {
     var user = await Api.CreateUserAsync();
@@ -18,6 +23,11 @@ public class Navigation : MobileAppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "mobile-happy-002",
+    FeatureArea = "mobile",
+    Behavior = "Hamburger menu button is visible on mobile viewport",
+    Verifies = ["Hamburger button is visible"])]
   public async Task HamburgerButtonIsVisibleOnMobile()
   {
     var user = await Api.CreateUserAsync();
@@ -27,6 +37,11 @@ public class Navigation : MobileAppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "mobile-happy-003",
+    FeatureArea = "mobile",
+    Behavior = "Tapping hamburger button opens the sidebar",
+    Verifies = ["SideNav becomes visible"])]
   public async Task HamburgerToggleOpensSidebar()
   {
     var user = await Api.CreateUserAsync();
@@ -38,6 +53,11 @@ public class Navigation : MobileAppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "mobile-happy-004",
+    FeatureArea = "mobile",
+    Behavior = "Tapping a nav link navigates to the page and closes the sidebar",
+    Verifies = ["URL changes to /settings", "SideNav closes after navigation"])]
   public async Task NavLinkNavigatesAndClosesSidebar()
   {
     var user = await Api.CreateUserAsync();
@@ -58,6 +78,11 @@ public class Navigation : MobileAppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "mobile-happy-005",
+    FeatureArea = "mobile",
+    Behavior = "Unauthenticated user sees Sign in and Sign up links in mobile sidebar",
+    Verifies = ["'Sign in' link visible in SideNav", "'Sign up' link visible in SideNav"])]
   public async Task UnauthenticatedUserSeesSignInSignUp()
   {
     await Pages.LoginPage.GoToAsync();

--- a/Test/e2e/E2eTests/Tests/Mobile/Screenshots.cs
+++ b/Test/e2e/E2eTests/Tests/Mobile/Screenshots.cs
@@ -7,6 +7,11 @@ public class Screenshots : MobileAppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "mobile-screenshots-001",
+    FeatureArea = "mobile",
+    Behavior = "Login page renders correctly on mobile with no horizontal overflow",
+    Verifies = ["Screenshot width within viewport"])]
   public async Task LoginPage()
   {
     await Pages.LoginPage.GoToAsync();
@@ -16,6 +21,11 @@ public class Screenshots : MobileAppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "mobile-screenshots-002",
+    FeatureArea = "mobile",
+    Behavior = "Register page renders correctly on mobile with no horizontal overflow",
+    Verifies = ["Screenshot width within viewport"])]
   public async Task RegisterPage()
   {
     await Pages.RegisterPage.GoToAsync();
@@ -25,6 +35,11 @@ public class Screenshots : MobileAppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "mobile-screenshots-003",
+    FeatureArea = "mobile",
+    Behavior = "Settings page renders correctly on mobile with no horizontal overflow",
+    Verifies = ["Screenshot width within viewport"])]
   public async Task SettingsPage()
   {
     var user = await Api.CreateUserAsync();
@@ -36,6 +51,11 @@ public class Screenshots : MobileAppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "mobile-screenshots-004",
+    FeatureArea = "mobile",
+    Behavior = "Dashboard page renders correctly on mobile with no horizontal overflow",
+    Verifies = ["Screenshot width within viewport"])]
   public async Task DashboardPage()
   {
     var user = await Api.CreateUserAsync();
@@ -47,6 +67,11 @@ public class Screenshots : MobileAppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "mobile-screenshots-005",
+    FeatureArea = "mobile",
+    Behavior = "Sidebar open state renders correctly on mobile with no horizontal overflow",
+    Verifies = ["Screenshot width within viewport"])]
   public async Task SidebarOpenOnMobile()
   {
     var user = await Api.CreateUserAsync();

--- a/Test/e2e/E2eTests/Tests/Multitenancy/MultitenancyTests.cs
+++ b/Test/e2e/E2eTests/Tests/Multitenancy/MultitenancyTests.cs
@@ -11,6 +11,11 @@ public class MultitenancyTests : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "multitenancy-happy-001",
+    FeatureArea = "multitenancy",
+    Behavior = "Users from different tenants cannot see each other's profiles",
+    Verifies = ["Profile page shows 'was not found' for cross-tenant user"])]
   public async Task Users_AreIsolated_BetweenTenants()
   {
     // Arrange - create two separate tenants with users
@@ -30,6 +35,11 @@ public class MultitenancyTests : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "multitenancy-happy-002",
+    FeatureArea = "multitenancy",
+    Behavior = "Duplicate usernames are allowed across different tenants",
+    Verifies = ["Both tenants can use same username", "Profile pages show correct username for each tenant"])]
   public async Task DuplicateUsernames_AreAllowed_BetweenTenants()
   {
     // Arrange - create two separate tenants with users

--- a/Test/e2e/E2eTests/Tests/ProfilePage/HappyPath.cs
+++ b/Test/e2e/E2eTests/Tests/ProfilePage/HappyPath.cs
@@ -10,6 +10,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "profile-happy-001",
+    FeatureArea = "profile",
+    Behavior = "User can view their own profile page",
+    Verifies = ["Profile heading shows user's email"])]
   public async Task UserCanViewOwnProfile()
   {
     // Arrange
@@ -26,6 +31,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "profile-happy-002",
+    FeatureArea = "profile",
+    Behavior = "User can view another user's profile within same tenant",
+    Verifies = ["Profile heading shows other user's email"])]
   public async Task UserCanViewOtherUsersProfile()
   {
     // Arrange

--- a/Test/e2e/E2eTests/Tests/ProfilePage/Permissions.cs
+++ b/Test/e2e/E2eTests/Tests/ProfilePage/Permissions.cs
@@ -10,6 +10,11 @@ public class Permissions : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "profile-permissions-001",
+    FeatureArea = "auth",
+    Behavior = "Unauthenticated user accessing dashboard is redirected to login",
+    Verifies = ["URL changes to /login"])]
   public async Task UnauthenticatedUser_RedirectsToLogin_WhenAccessingDashboard()
   {
     // Act - try to access dashboard without authentication
@@ -20,6 +25,11 @@ public class Permissions : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "profile-permissions-002",
+    FeatureArea = "auth",
+    Behavior = "Unauthenticated user accessing profile page is redirected to login",
+    Verifies = ["URL changes to /login"])]
   public async Task UnauthenticatedUser_RedirectsToLogin_WhenAccessingProfilePage()
   {
     // Arrange

--- a/Test/e2e/E2eTests/Tests/RegisterPage/HappyPath.cs
+++ b/Test/e2e/E2eTests/Tests/RegisterPage/HappyPath.cs
@@ -10,6 +10,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "register-happy-001",
+    FeatureArea = "auth",
+    Behavior = "New tenant signup creates admin user who sees Users nav item",
+    Verifies = ["Redirects to home page", "Users nav link visible", "Users page accessible"])]
   public async Task NewTenantSignup_ShowsUsersNavItem()
   {
     // Arrange

--- a/Test/e2e/E2eTests/Tests/RegisterPage/Validation.cs
+++ b/Test/e2e/E2eTests/Tests/RegisterPage/Validation.cs
@@ -10,6 +10,11 @@ public class Validation : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "register-validation-001",
+    FeatureArea = "auth",
+    Behavior = "Registration with duplicate email shows error message",
+    Verifies = ["Error message contains 'already been registered with that email'"])]
   public async Task Register_WithDuplicateEmail_DisplaysErrorMessage()
   {
     // Arrange
@@ -27,6 +32,11 @@ public class Validation : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "register-validation-002",
+    FeatureArea = "auth",
+    Behavior = "Registration with duplicate username shows error message",
+    Verifies = ["Error message contains 'already been registered with that email'"])]
   public async Task Register_WithDuplicateUsername_DisplaysErrorMessage()
   {
     // Arrange

--- a/Test/e2e/E2eTests/Tests/SettingsPage/HappyPath.cs
+++ b/Test/e2e/E2eTests/Tests/SettingsPage/HappyPath.cs
@@ -12,6 +12,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "settings-happy-001",
+    FeatureArea = "settings",
+    Behavior = "User can update bio and see it reflected on profile page",
+    Verifies = ["Bio text visible on profile page after update"])]
   public async Task UserCanEditProfile()
   {
     // Arrange
@@ -35,6 +40,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "settings-happy-002",
+    FeatureArea = "settings",
+    Behavior = "User can change language to Japanese and see translated UI",
+    Verifies = ["Success message in Japanese", "Sidebar nav in Japanese", "Page title in Japanese", "Dashboard welcome text in Japanese"])]
   public async Task UserCanChangeLanguageToJapanese()
   {
     // Arrange
@@ -72,6 +82,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "settings-happy-003",
+    FeatureArea = "settings",
+    Behavior = "User can sign out via sidebar logout button",
+    Verifies = ["User is logged out after clicking logout"])]
   public async Task UserCanSignOut()
   {
     // Arrange

--- a/Test/e2e/E2eTests/Tests/SettingsPage/Validation.cs
+++ b/Test/e2e/E2eTests/Tests/SettingsPage/Validation.cs
@@ -10,6 +10,11 @@ public class Validation : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "settings-validation-001",
+    FeatureArea = "settings",
+    Behavior = "Updating username to a duplicate shows error message",
+    Verifies = ["Error message contains 'Username already exists'"])]
   public async Task UpdateSettings_WithDuplicateUsername_DisplaysErrorMessage()
   {
     // Arrange - create two users in the same tenant
@@ -29,6 +34,11 @@ public class Validation : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "settings-validation-002",
+    FeatureArea = "settings",
+    Behavior = "Updating email to a duplicate shows error message",
+    Verifies = ["Error message contains 'Email already exists'"])]
   public async Task UpdateSettings_WithDuplicateEmail_DisplaysErrorMessage()
   {
     // Arrange - create two users in the same tenant

--- a/Test/e2e/E2eTests/Tests/SwaggerPage/HappyPath.cs
+++ b/Test/e2e/E2eTests/Tests/SwaggerPage/HappyPath.cs
@@ -10,6 +10,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "swagger-happy-001",
+    FeatureArea = "swagger",
+    Behavior = "Swagger API documentation page loads and displays API info",
+    Verifies = ["API info section is visible"])]
   public async Task SwaggerApiDocs_AreDisplayed()
   {
     // Arrange & Act

--- a/Test/e2e/E2eTests/Tests/UsersPage/HappyPath.cs
+++ b/Test/e2e/E2eTests/Tests/UsersPage/HappyPath.cs
@@ -10,6 +10,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-happy-001",
+    FeatureArea = "users",
+    Behavior = "Admin can navigate to Users page from sidebar menu",
+    Verifies = ["Users heading visible", "Invite User button visible"])]
   public async Task NavigateToUsersPageFromMenu()
   {
     // Arrange - create and log in a user
@@ -24,6 +29,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-happy-002",
+    FeatureArea = "users",
+    Behavior = "Admin can invite a user who can then log in",
+    Verifies = ["Invited user appears in table", "Invited user can log in and reach home page"])]
   public async Task InviteUserThenLogoutAndLoginAsInvitedUser()
   {
     // Arrange - create and log in an admin user
@@ -55,6 +65,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-happy-003",
+    FeatureArea = "users",
+    Behavior = "Clicking a user's profile link navigates to their profile page",
+    Verifies = ["URL changes to /profile/{username}"])]
   public async Task ClickUserProfileLinkNavigatesToProfile()
   {
     // Arrange - create one user and invite another to same tenant
@@ -81,6 +96,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-happy-004",
+    FeatureArea = "users",
+    Behavior = "Deactivated user shows 'Deactivated' status in the users table",
+    Verifies = ["Status tag contains 'Deactivated'"])]
   public async Task DeactivateUserThenVerifyStatusColumn()
   {
     // Arrange - create admin and invite a user
@@ -102,6 +122,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-happy-005",
+    FeatureArea = "users",
+    Behavior = "Admin can deactivate and reactivate a user via the UI",
+    Verifies = ["Status shows 'Deactivated' after deactivation", "Status shows 'Active' after reactivation"])]
   public async Task DeactivateAndReactivateUser()
   {
     // Arrange
@@ -128,6 +153,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-happy-006",
+    FeatureArea = "users",
+    Behavior = "Deactivated user cannot log in and sees lockout error",
+    Verifies = ["Error message contains 'Account is locked out'"])]
   public async Task DeactivatedUserCannotLogin()
   {
     // Arrange - deactivate an invited user
@@ -145,6 +175,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-happy-007",
+    FeatureArea = "users",
+    Behavior = "Admin can add ADMIN role to a user via edit roles modal",
+    Verifies = ["User row shows 'ADMIN' in roles column"])]
   public async Task EditUserRolesAddsAdminRole()
   {
     // Arrange
@@ -166,6 +201,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-happy-008",
+    FeatureArea = "users",
+    Behavior = "Admin can remove ADMIN role from a user via edit roles modal",
+    Verifies = ["User row no longer shows 'ADMIN'", "User row still shows 'USER'"])]
   public async Task EditUserRolesRemovesAdminRole()
   {
     // Arrange - create admin, invite user, give them ADMIN role via API
@@ -190,6 +230,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-happy-009",
+    FeatureArea = "users",
+    Behavior = "OWNER role checkbox is read-only in edit roles modal",
+    Verifies = ["OWNER checkbox is disabled"])]
   public async Task OwnerRoleIsReadOnlyInEditModal()
   {
     // Arrange - log in as the owner/admin
@@ -208,6 +253,11 @@ public class HappyPath : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-happy-010",
+    FeatureArea = "users",
+    Behavior = "Pagination displays correct total user count",
+    Verifies = ["Pagination is visible", "Pagination contains correct count"])]
   public async Task PaginationShowsCorrectCount()
   {
     // Arrange - create admin and invite a user

--- a/Test/e2e/E2eTests/Tests/UsersPage/Permissions.cs
+++ b/Test/e2e/E2eTests/Tests/UsersPage/Permissions.cs
@@ -9,6 +9,11 @@ public class Permissions : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-permissions-001",
+    FeatureArea = "users",
+    Behavior = "Admin user sees Users link in sidebar navigation",
+    Verifies = ["Users link is visible"])]
   public async Task AdminUserSeesUsersLinkInNavigation()
   {
     // Arrange - create and log in an ADMIN user (first user in tenant)
@@ -24,6 +29,11 @@ public class Permissions : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-permissions-002",
+    FeatureArea = "users",
+    Behavior = "Non-admin user does not see Users link in sidebar navigation",
+    Verifies = ["Users link is not visible"])]
   public async Task NonAdminUserDoesNotSeeUsersLinkInNavigation()
   {
     // Arrange - create ADMIN user, then invite non-ADMIN user
@@ -43,6 +53,11 @@ public class Permissions : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-permissions-003",
+    FeatureArea = "users",
+    Behavior = "Non-admin user redirected to 403 Forbidden when accessing /users directly",
+    Verifies = ["URL changes to /forbidden", "403 heading visible", "Permission denied message visible"])]
   public async Task NonAdminUserRedirectedToForbiddenWhenAccessingUsersPage()
   {
     // Arrange - create ADMIN user, then invite non-ADMIN user
@@ -64,6 +79,11 @@ public class Permissions : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-permissions-004",
+    FeatureArea = "users",
+    Behavior = "Forbidden page has a link back to the home page",
+    Verifies = ["'Go back to home' link navigates to /"])]
   public async Task ForbiddenPageHasLinkToHomePage()
   {
     // Arrange - create ADMIN user, then invite non-ADMIN user
@@ -88,6 +108,11 @@ public class Permissions : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-permissions-005",
+    FeatureArea = "users",
+    Behavior = "Admin cannot deactivate their own account",
+    Verifies = ["Deactivate option not visible in self overflow menu"])]
   public async Task AdminCannotDeactivateSelf()
   {
     // Arrange - log in as admin
@@ -105,6 +130,11 @@ public class Permissions : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-permissions-006",
+    FeatureArea = "users",
+    Behavior = "Admin cannot remove their own ADMIN role",
+    Verifies = ["Error message 'Cannot remove your own ADMIN role' visible"])]
   public async Task AdminCannotRemoveOwnAdminRole()
   {
     // Arrange - log in as admin

--- a/Test/e2e/E2eTests/Tests/UsersPage/Screenshots.cs
+++ b/Test/e2e/E2eTests/Tests/UsersPage/Screenshots.cs
@@ -10,6 +10,11 @@ public class Screenshots : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-screenshots-001",
+    FeatureArea = "users",
+    Behavior = "Users page renders correctly with multiple users and no horizontal overflow",
+    Verifies = ["Table headers visible", "User rows visible", "Screenshot width within viewport"])]
   public async Task UsersPageWithMultipleUsers()
   {
     // Arrange - create one user and invite two others to same tenant
@@ -43,6 +48,11 @@ public class Screenshots : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-screenshots-002",
+    FeatureArea = "users",
+    Behavior = "Users page with pagination renders correctly and no horizontal overflow",
+    Verifies = ["Pagination visible", "Screenshot width within viewport"])]
   public async Task UsersPageWithPagination()
   {
     // Arrange - create admin and invite a user
@@ -62,6 +72,11 @@ public class Screenshots : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-screenshots-003",
+    FeatureArea = "users",
+    Behavior = "Users page with deactivated user renders correctly",
+    Verifies = ["Deactivated status tag visible", "Screenshot width within viewport"])]
   public async Task UsersPageWithDeactivatedUser()
   {
     // Arrange - create admin, invite user, then deactivate them
@@ -83,6 +98,11 @@ public class Screenshots : AppPageTest
   }
 
   [Fact]
+  [TestCoverage(
+    Id = "users-screenshots-004",
+    FeatureArea = "users",
+    Behavior = "Edit roles modal renders correctly when open",
+    Verifies = ["Screenshot width within viewport"])]
   public async Task EditRolesModalOpen()
   {
     // Arrange

--- a/Test/e2e/docker-compose.yml
+++ b/Test/e2e/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       - DOTNET_RUNNING_IN_DOCKER=1
       - DEBUG=pw:api
       - CI=true
+      - PLAYWRIGHT_ALWAYS_TRACE=${PLAYWRIGHT_ALWAYS_TRACE:-false}
       - NODE_TLS_REJECT_UNAUTHORIZED=0
 
 networks:

--- a/scripts/evals/README.md
+++ b/scripts/evals/README.md
@@ -1,0 +1,91 @@
+# Trace-Based Eval System
+
+Evals for the tests. Tests verify code correctness; these evals verify that the tests actually prove what they claim.
+
+## Architecture
+
+```
+Layer 1: Tests run against the app (mechanical pass/fail)
+Layer 2: Traces graded by model (independent observational judge)
+
+SPEC-REFERENCE.md → generate-expectations.sh → expectations.json
+                                                     ↓
+Playwright traces → extract-trace.sh → JSON → grade-trace.sh → verdict
+                                                     ↓
+                                          eval-traces.sh → report
+```
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `extract-trace.sh` | Unzips a Playwright trace, extracts actions/network/DOM/console into JSON |
+| `generate-expectations.sh` | Uses Claude to produce expectations.json from the spec |
+| `grade-trace.sh` | Grades one extracted trace against one expectation → PASS/WEAK/FAIL |
+| `eval-traces.sh` | Orchestrates: extract all traces → match to expectations → grade → report |
+| `create-test-trace.sh` | Generates synthetic traces for testing the pipeline |
+
+## Usage
+
+### Full pipeline
+```bash
+# 1. Generate expectations from spec (one-time, or when spec changes)
+./scripts/evals/generate-expectations.sh --spec SPEC-REFERENCE.md --output expectations.json
+
+# 2. Run tests with tracing always on (see "Enabling always-on tracing" below)
+./build.sh TestE2e --agent
+
+# 3. Evaluate the traces
+./scripts/evals/eval-traces.sh Reports/Test/e2e/Artifacts/ expectations.json --output eval-results/
+```
+
+### Individual trace grading
+```bash
+# Extract a single trace
+./scripts/evals/extract-trace.sh path/to/trace.zip > extracted.json
+
+# Grade it against an expectation
+./scripts/evals/grade-trace.sh extracted.json expectation.json
+```
+
+## Verdicts
+
+- **PASS** — Trace demonstrates all key assertions. Actions, network, and UI all match.
+- **WEAK** — Feature appears to work but test assertions don't fully verify it. A broken app could also pass this test.
+- **FAIL** — Trace does not demonstrate expected behavior. Errors, wrong responses, or missing actions.
+
+## Scoring
+
+```
+PASS  = 1.0 points
+WEAK  = 0.4 points
+FAIL  = 0.0 points
+Score = (total points / graded traces) * 100
+```
+
+## Enabling always-on tracing
+
+By default, `AppPageTest` only saves traces for failed tests. For evals, you need traces for ALL tests. Apply this change to `Test/e2e/E2eTests/AppPageTest.cs`:
+
+In `StopTracingAsync()`, change the conditional save to always save:
+```csharp
+// Always save traces for eval grading
+await Context.Tracing.StopAsync(new()
+{
+    Path = Path.Combine(Constants.ReportsTestE2eArtifacts,
+        $"{testName}_trace_{DateTime.Now:yyyyMMdd_HHmmss}.zip"),
+});
+```
+
+## Trace format
+
+Playwright traces are ZIP files containing NDJSON:
+- `trace.trace` — action events (before/after pairs), DOM snapshots, console, screenshots
+- `trace.network` — HTTP request/response events
+- `resources/` — binary blobs (screenshots as JPEG, DOM as HTML, response bodies)
+
+## Matching traces to expectations
+
+Trace filenames are fuzzy-matched to expectation names:
+- `UserCanSignIn_WithExistingCredentials_trace_20260407.zip` matches `auth-001` (name: `UserCanSignIn_WithExistingCredentials`)
+- Unmatched traces get generic grading ("describe what this demonstrates")

--- a/scripts/evals/create-test-trace.sh
+++ b/scripts/evals/create-test-trace.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# create-test-trace.sh — Generate a synthetic Playwright trace zip for testing the eval pipeline
+#
+# Creates a realistic-looking trace with NDJSON action log, network entries,
+# and fake resources. Useful for verifying extract → grade pipeline without
+# running actual Playwright tests.
+#
+# Usage: ./scripts/evals/create-test-trace.sh <output-dir> [--scenario good|weak|bad]
+
+set -euo pipefail
+
+OUTPUT_DIR="${1:?Usage: create-test-trace.sh <output-dir> [--scenario good|weak|bad]}"
+SCENARIO="good"
+
+shift || true
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --scenario) SCENARIO="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+mkdir -p "$OUTPUT_DIR"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+mkdir -p "$TMPDIR/resources"
+
+WALL_TIME=$(date +%s)000
+
+# Generate trace.trace (NDJSON)
+generate_trace_events() {
+  local t=$WALL_TIME
+
+  # Context options
+  cat <<EOF
+{"type":"context-options","options":{"viewport":{"width":1280,"height":720},"userAgent":"Mozilla/5.0 E2E-Test-Suite","ignoreHTTPSErrors":true},"wallTime":$t}
+EOF
+
+  if [[ "$SCENARIO" == "good" || "$SCENARIO" == "weak" ]]; then
+    # Navigate to login
+    cat <<EOF
+{"type":"before","callId":"call@1","class":"Page","method":"goto","apiName":"page.goto","params":{"url":"https://localhost:5001/login"},"wallTime":$((t+100)),"startTime":$((t+100))}
+{"type":"after","callId":"call@1","endTime":$((t+300))}
+EOF
+
+    # Fill email
+    cat <<EOF
+{"type":"before","callId":"call@2","class":"Locator","method":"fill","apiName":"locator.fill","params":{"selector":"getByPlaceholder('Email')","value":"testuser1@test.com"},"wallTime":$((t+400)),"startTime":$((t+400))}
+{"type":"after","callId":"call@2","endTime":$((t+500))}
+EOF
+
+    # Fill password
+    cat <<EOF
+{"type":"before","callId":"call@3","class":"Locator","method":"fill","apiName":"locator.fill","params":{"selector":"getByPlaceholder('Password')","value":"TestPassword123!"},"wallTime":$((t+600)),"startTime":$((t+600))}
+{"type":"after","callId":"call@3","endTime":$((t+700))}
+EOF
+
+    # Click sign in
+    cat <<EOF
+{"type":"before","callId":"call@4","class":"Locator","method":"click","apiName":"locator.click","params":{"selector":"getByRole('button', { name: 'Sign in' })"},"wallTime":$((t+800)),"startTime":$((t+800))}
+{"type":"after","callId":"call@4","endTime":$((t+900))}
+EOF
+
+    if [[ "$SCENARIO" == "good" ]]; then
+      # Expect assertion — settings link visible (strong assertion)
+      cat <<EOF
+{"type":"before","callId":"call@5","class":"LocatorAssertions","method":"toBeVisible","apiName":"expect(locator).toBeVisible","params":{"selector":"getByRole('link', { name: 'Settings' })"},"wallTime":$((t+1000)),"startTime":$((t+1000))}
+{"type":"after","callId":"call@5","endTime":$((t+1100))}
+EOF
+
+      # Expect assertion — user profile link visible (verifies logged in as correct user)
+      cat <<EOF
+{"type":"before","callId":"call@6","class":"LocatorAssertions","method":"toBeVisible","apiName":"expect(locator).toBeVisible","params":{"selector":"getByRole('link', { name: 'testuser1@test.com' })"},"wallTime":$((t+1200)),"startTime":$((t+1200))}
+{"type":"after","callId":"call@6","endTime":$((t+1300))}
+EOF
+    else
+      # Weak scenario — only checks page loaded, no content verification
+      cat <<EOF
+{"type":"before","callId":"call@5","class":"PageAssertions","method":"toHaveURL","apiName":"expect(page).toHaveURL","params":{"url":"https://localhost:5001/"},"wallTime":$((t+1000)),"startTime":$((t+1000))}
+{"type":"after","callId":"call@5","endTime":$((t+1100))}
+EOF
+    fi
+
+  else
+    # Bad scenario — login fails
+    cat <<EOF
+{"type":"before","callId":"call@1","class":"Page","method":"goto","apiName":"page.goto","params":{"url":"https://localhost:5001/login"},"wallTime":$((t+100)),"startTime":$((t+100))}
+{"type":"after","callId":"call@1","endTime":$((t+300))}
+EOF
+
+    cat <<EOF
+{"type":"before","callId":"call@2","class":"Locator","method":"fill","apiName":"locator.fill","params":{"selector":"getByPlaceholder('Email')","value":"testuser1@test.com"},"wallTime":$((t+400)),"startTime":$((t+400))}
+{"type":"after","callId":"call@2","endTime":$((t+500))}
+EOF
+
+    cat <<EOF
+{"type":"before","callId":"call@3","class":"Locator","method":"fill","apiName":"locator.fill","params":{"selector":"getByPlaceholder('Password')","value":"WrongPassword!"},"wallTime":$((t+600)),"startTime":$((t+600))}
+{"type":"after","callId":"call@3","endTime":$((t+700))}
+EOF
+
+    cat <<EOF
+{"type":"before","callId":"call@4","class":"Locator","method":"click","apiName":"locator.click","params":{"selector":"getByRole('button', { name: 'Sign in' })"},"wallTime":$((t+800)),"startTime":$((t+800))}
+{"type":"after","callId":"call@4","endTime":$((t+900))}
+EOF
+
+    # Expect times out — assertion fails
+    cat <<EOF
+{"type":"before","callId":"call@5","class":"LocatorAssertions","method":"toBeVisible","apiName":"expect(locator).toBeVisible","params":{"selector":"getByRole('link', { name: 'Settings' })"},"wallTime":$((t+1000)),"startTime":$((t+1000))}
+{"type":"after","callId":"call@5","error":{"message":"Timeout 10000ms exceeded. Waiting for locator('role=link[name=\"Settings\"]') to be visible"},"endTime":$((t+11000))}
+EOF
+
+    # Console error
+    cat <<EOF
+{"type":"console","messageType":"error","text":"POST /api/identity/login 401 Unauthorized","url":"https://localhost:5001/login","lineNumber":1,"wallTime":$((t+900))}
+EOF
+  fi
+}
+
+# Generate trace.network (NDJSON)
+generate_network_events() {
+  if [[ "$SCENARIO" == "good" || "$SCENARIO" == "weak" ]]; then
+    cat <<EOF
+{"request":{"method":"POST","url":"https://localhost:5001/api/identity/login?useCookies=false","headers":[{"name":"content-type","value":"application/json"}],"postData":"{\"email\":\"testuser1@test.com\",\"password\":\"TestPassword123!\"}"},"response":{"status":200,"statusText":"OK","headers":[{"name":"content-type","value":"application/json"}]},"resourceType":"fetch"}
+{"request":{"method":"GET","url":"https://localhost:5001/api/user","headers":[{"name":"authorization","value":"Bearer eyJhbG..."}]},"response":{"status":200,"statusText":"OK","headers":[{"name":"content-type","value":"application/json"}]},"resourceType":"fetch"}
+{"request":{"method":"GET","url":"https://localhost:5001/api/feature-flags","headers":[]},"response":{"status":200,"statusText":"OK","headers":[]},"resourceType":"fetch"}
+EOF
+  else
+    cat <<EOF
+{"request":{"method":"POST","url":"https://localhost:5001/api/identity/login?useCookies=false","headers":[{"name":"content-type","value":"application/json"}],"postData":"{\"email\":\"testuser1@test.com\",\"password\":\"WrongPassword!\"}"},"response":{"status":401,"statusText":"Unauthorized","headers":[]},"resourceType":"fetch"}
+EOF
+  fi
+}
+
+# Write files
+generate_trace_events > "$TMPDIR/trace.trace"
+generate_network_events > "$TMPDIR/trace.network"
+
+# Create a fake DOM snapshot resource
+DOM_SHA="abc123def456"
+echo '<html><body><nav><a href="/settings">Settings</a><a href="/profile/testuser1@test.com">testuser1@test.com</a></nav><h1>Dashboard</h1><p>Welcome, testuser1@test.com</p></body></html>' > "$TMPDIR/resources/$DOM_SHA"
+
+# Package as zip
+TRACE_NAME="UserCanSignIn_WithExistingCredentials_trace_$(date +%Y%m%d_%H%M%S)"
+(cd "$TMPDIR" && zip -q -r "$OUTPUT_DIR/${TRACE_NAME}.zip" trace.trace trace.network resources/)
+
+echo "Created: $OUTPUT_DIR/${TRACE_NAME}.zip (scenario: $SCENARIO)" >&2
+echo "$OUTPUT_DIR/${TRACE_NAME}.zip"

--- a/scripts/evals/eval-coverage.sh
+++ b/scripts/evals/eval-coverage.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+# eval-coverage.sh — Assert generated expectations cover the master list
+#
+# Compares expectations.json (generated from spec) against master-list.json
+# (extracted from existing tests) to find gaps. Uses Claude for semantic
+# matching since names won't match exactly.
+#
+# Usage: ./scripts/evals/eval-coverage.sh <master-list.json> <expectations.json> [--output FILE]
+#
+# Output: coverage-report.json with matched/unmatched/weak coverage analysis
+
+set -euo pipefail
+
+MASTER_LIST_FILE="${1:?Usage: eval-coverage.sh <master-list.json> <expectations.json> [--output FILE]}"
+EXPECTATIONS_FILE="${2:?Usage: eval-coverage.sh <master-list.json> <expectations.json> [--output FILE]}"
+OUTPUT_FILE=""
+
+shift 2 || true
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --output) OUTPUT_FILE="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ ! -f "$MASTER_LIST_FILE" ]]; then
+  echo "ERROR: Master list not found: $MASTER_LIST_FILE" >&2
+  exit 1
+fi
+
+if [[ ! -f "$EXPECTATIONS_FILE" ]]; then
+  echo "ERROR: Expectations file not found: $EXPECTATIONS_FILE" >&2
+  exit 1
+fi
+
+MASTER_LIST=$(cat "$MASTER_LIST_FILE")
+EXPECTATIONS=$(cat "$EXPECTATIONS_FILE")
+
+MASTER_COUNT=$(echo "$MASTER_LIST" | jq '.actual_test_count')
+EXPECTATIONS_COUNT=$(echo "$EXPECTATIONS" | jq '.total_expectations')
+
+echo "Master list: $MASTER_COUNT tests" >&2
+echo "Expectations: $EXPECTATIONS_COUNT expectations" >&2
+echo "" >&2
+
+# Build the comparison prompt
+PROMPT=$(cat <<'PROMPT_EOF'
+You are comparing two sets of test coverage descriptions:
+
+1. MASTER LIST — extracted from an existing, hand-written E2E test suite. This is the ground truth of what we know should be tested.
+2. GENERATED EXPECTATIONS — produced by a model reading the API spec. This is what the generator thinks should be tested.
+
+Your task: for each test in the master list, determine whether the generated expectations adequately cover that test case.
+
+For each master list entry, produce:
+```json
+{
+  "master_id": "auth-happy-001",
+  "master_method": "UserCanSignIn_WithExistingCredentials",
+  "master_behavior": "User can log in with valid credentials",
+  "match_status": "covered" | "weak" | "missing",
+  "matched_expectation_id": "auth-001" or null,
+  "match_reasoning": "Why this is covered/weak/missing"
+}
+```
+
+Match criteria:
+- **covered**: An expectation exists that tests the same behavior AND has key_assertions that would verify the same things the master test checks
+- **weak**: An expectation exists for the same feature area but doesn't fully cover the specific behavior (e.g., expectation tests login but doesn't check the specific error message the master test verifies)
+- **missing**: No expectation covers this behavior at all
+
+Rules:
+1. Every master list entry must get exactly one match result
+2. Multiple master entries CAN match the same expectation (that's fine — one expectation may cover what the existing suite splits across multiple tests)
+3. Be strict about "covered" — the expectation must actually verify the same thing, not just be in the same area
+4. Screenshots tests can be marked "covered" if any expectation covers the same page (screenshot tests are visual regression, not behavioral)
+5. For multitenancy tests, look for isolation/tenant-specific expectations
+
+Output ONLY the JSON array, no markdown fencing, no explanation.
+
+## MASTER LIST (ground truth — from existing tests)
+
+PROMPT_EOF
+)
+
+MASTER_TESTS=$(echo "$MASTER_LIST" | jq '[.tests[] | {id, test_method, behavior_tested, key_verifications, feature_area, category}]')
+EXPECTATION_LIST=$(echo "$EXPECTATIONS" | jq '[.expectations[] | {id, name, expected_behavior, key_assertions, feature_area, category}]')
+
+FULL_PROMPT="$PROMPT
+
+$MASTER_TESTS
+
+## GENERATED EXPECTATIONS (from spec — must cover master list)
+
+$EXPECTATION_LIST"
+
+echo "Sending to Claude for coverage analysis..." >&2
+
+RESULT=$(echo "$FULL_PROMPT" | claude -p --output-format json 2>/dev/null)
+
+# Extract text content
+MATCHES=$(echo "$RESULT" | jq -r '
+  if type == "array" then
+    map(select(.type == "text") | .text) | join("")
+  elif .result then
+    .result
+  elif .content then
+    if (.content | type) == "array" then
+      .content | map(select(.type == "text") | .text) | join("")
+    else
+      .content
+    end
+  else
+    tostring
+  end
+' 2>/dev/null || echo "$RESULT")
+
+# Validate JSON
+if ! echo "$MATCHES" | jq 'if type == "array" then . else error("not an array") end' >/dev/null 2>&1; then
+  MATCHES=$(echo "$MATCHES" | grep -o '\[.*\]' | head -1)
+  if ! echo "$MATCHES" | jq '.' >/dev/null 2>&1; then
+    echo "ERROR: Failed to parse coverage analysis" >&2
+    echo "Raw output saved to /tmp/coverage-raw.txt" >&2
+    echo "$RESULT" > /tmp/coverage-raw.txt
+    exit 1
+  fi
+fi
+
+# Compute summary stats
+COVERED=$(echo "$MATCHES" | jq '[.[] | select(.match_status == "covered")] | length')
+WEAK=$(echo "$MATCHES" | jq '[.[] | select(.match_status == "weak")] | length')
+MISSING=$(echo "$MATCHES" | jq '[.[] | select(.match_status == "missing")] | length')
+TOTAL=$(echo "$MATCHES" | jq 'length')
+
+# Coverage score: covered=1.0, weak=0.5, missing=0.0
+if [[ "$TOTAL" -gt 0 ]]; then
+  COVERAGE_SCORE=$(echo "scale=1; ($COVERED * 100 + $WEAK * 50) / $TOTAL" | bc)
+else
+  COVERAGE_SCORE=0
+fi
+
+# Build report
+REPORT=$(jq -n \
+  --argjson matches "$MATCHES" \
+  --argjson covered "$COVERED" \
+  --argjson weak "$WEAK" \
+  --argjson missing "$MISSING" \
+  --argjson total "$TOTAL" \
+  --argjson coverage_score "$COVERAGE_SCORE" \
+  --argjson master_count "$MASTER_COUNT" \
+  --argjson expectations_count "$EXPECTATIONS_COUNT" \
+  --arg generated_at "$(date -Iseconds)" \
+  '{
+    generated_at: $generated_at,
+    score: {
+      coverage: $coverage_score,
+      max: 100,
+      formula: "covered=1.0, weak=0.5, missing=0.0"
+    },
+    summary: {
+      master_test_count: $master_count,
+      generated_expectation_count: $expectations_count,
+      total_evaluated: $total,
+      covered: $covered,
+      weak: $weak,
+      missing: $missing,
+      covered_pct: (if $total > 0 then (($covered * 100) / $total | floor) else 0 end),
+      gap_count: ($weak + $missing)
+    },
+    missing_tests: [
+      $matches[] | select(.match_status == "missing") |
+      { master_id, master_method, master_behavior, match_reasoning }
+    ],
+    weak_coverage: [
+      $matches[] | select(.match_status == "weak") |
+      { master_id, master_method, master_behavior, matched_expectation_id, match_reasoning }
+    ],
+    all_matches: $matches
+  }')
+
+# Output
+if [[ -n "$OUTPUT_FILE" ]]; then
+  echo "$REPORT" | jq '.' > "$OUTPUT_FILE"
+  echo "Wrote coverage report to $OUTPUT_FILE" >&2
+else
+  echo "$REPORT" | jq '.'
+fi
+
+# Print summary to stderr
+echo "" >&2
+echo "=== Coverage Results ===" >&2
+echo "Score:    $COVERAGE_SCORE / 100" >&2
+echo "Covered:  $COVERED / $TOTAL" >&2
+echo "Weak:     $WEAK / $TOTAL" >&2
+echo "Missing:  $MISSING / $TOTAL" >&2
+echo "" >&2
+
+if [[ "$MISSING" -gt 0 ]]; then
+  echo "=== Missing Test Cases ===" >&2
+  echo "$REPORT" | jq -r '.missing_tests[] | "  [\(.master_id)] \(.master_method): \(.master_behavior)"' >&2
+fi
+
+if [[ "$WEAK" -gt 0 ]]; then
+  echo "" >&2
+  echo "=== Weak Coverage ===" >&2
+  echo "$REPORT" | jq -r '.weak_coverage[] | "  [\(.master_id)] \(.master_method): \(.match_reasoning)"' >&2
+fi
+
+# Exit with failure if coverage is below threshold
+if [[ "$MISSING" -gt 0 ]]; then
+  echo "" >&2
+  echo "FAIL: $MISSING test cases from the master list are not covered by generated expectations" >&2
+  exit 1
+fi

--- a/scripts/evals/eval-traces.sh
+++ b/scripts/evals/eval-traces.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+# eval-traces.sh — Orchestrate the full trace eval pipeline
+#
+# Given a directory of Playwright trace zips and an expectations file,
+# extracts each trace, grades it against matched expectations, and
+# produces a summary report with composite scores.
+#
+# Usage: ./scripts/evals/eval-traces.sh <traces-dir> <expectations.json> [--output DIR]
+#
+# Trace files are matched to expectations by convention:
+#   - Trace filename contains the test name (e.g., "UserCanSignIn_trace_20260407.zip")
+#   - Matched against expectation.name using fuzzy substring match
+#   - Unmatched traces are graded with a generic "describe what this demonstrates" prompt
+#
+# Output: eval-report.json with all verdicts + composite score
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+TRACES_DIR="${1:?Usage: eval-traces.sh <traces-dir> <expectations.json> [--output DIR]}"
+EXPECTATIONS_FILE="${2:?Usage: eval-traces.sh <traces-dir> <expectations.json> [--output DIR]}"
+OUTPUT_DIR=""
+
+shift 2 || true
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --output) OUTPUT_DIR="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ ! -d "$TRACES_DIR" ]]; then
+  echo "ERROR: Traces directory not found: $TRACES_DIR" >&2
+  exit 1
+fi
+
+if [[ ! -f "$EXPECTATIONS_FILE" ]]; then
+  echo "ERROR: Expectations file not found: $EXPECTATIONS_FILE" >&2
+  exit 1
+fi
+
+# Set up output directory
+if [[ -z "$OUTPUT_DIR" ]]; then
+  OUTPUT_DIR="$TRACES_DIR/eval-results"
+fi
+mkdir -p "$OUTPUT_DIR/extracted" "$OUTPUT_DIR/verdicts" "$OUTPUT_DIR/screenshots"
+
+echo "=== Trace Eval Pipeline ===" >&2
+echo "Traces:       $TRACES_DIR" >&2
+echo "Expectations: $EXPECTATIONS_FILE" >&2
+echo "Output:       $OUTPUT_DIR" >&2
+echo "" >&2
+
+# Load expectations
+EXPECTATIONS=$(cat "$EXPECTATIONS_FILE")
+TOTAL_EXPECTATIONS=$(echo "$EXPECTATIONS" | jq '.total_expectations')
+echo "Loaded $TOTAL_EXPECTATIONS expectations" >&2
+
+# Find all trace zips
+TRACE_ZIPS=()
+for f in "$TRACES_DIR"/*.zip; do
+  [[ -f "$f" ]] && TRACE_ZIPS+=("$f")
+done
+
+if [[ ${#TRACE_ZIPS[@]} -eq 0 ]]; then
+  echo "ERROR: No .zip trace files found in $TRACES_DIR" >&2
+  exit 1
+fi
+
+echo "Found ${#TRACE_ZIPS[@]} trace files" >&2
+echo "" >&2
+
+# Match a trace filename to an expectation by fuzzy name matching
+match_expectation() {
+  local trace_name="$1"
+  # Normalize: remove _trace_, timestamps, .zip, convert to lowercase
+  local normalized
+  normalized=$(echo "$trace_name" | sed 's/_trace_[0-9_]*//g; s/\.zip$//; s/_/ /g' | tr '[:upper:]' '[:lower:]')
+
+  # Try to match against expectation names
+  echo "$EXPECTATIONS" | jq -r --arg search "$normalized" '
+    .expectations[] |
+    .name as $name |
+    ($name | gsub("(?<a>[A-Z])"; " \(.a)") | ltrimstr(" ") | ascii_downcase) as $normalized_name |
+    select(
+      ($search | contains($normalized_name)) or
+      ($normalized_name | contains($search)) or
+      # Try matching on individual words
+      ([$search | split(" ")[] | select(length > 3)] | any(. as $word | $normalized_name | contains($word)))
+    ) |
+    .id
+  ' | head -1
+}
+
+# Process each trace
+VERDICTS=()
+PROCESSED=0
+PASS_COUNT=0
+WEAK_COUNT=0
+FAIL_COUNT=0
+ERROR_COUNT=0
+
+for trace_zip in "${TRACE_ZIPS[@]}"; do
+  trace_name=$(basename "$trace_zip")
+  PROCESSED=$((PROCESSED + 1))
+  echo "[$PROCESSED/${#TRACE_ZIPS[@]}] Processing: $trace_name" >&2
+
+  # Step 1: Extract trace
+  extracted_file="$OUTPUT_DIR/extracted/${trace_name%.zip}.json"
+  echo "  Extracting..." >&2
+  if ! "$SCRIPT_DIR/extract-trace.sh" "$trace_zip" \
+    --screenshots-dir "$OUTPUT_DIR/screenshots/${trace_name%.zip}" \
+    > "$extracted_file" 2>/dev/null; then
+    echo "  ERROR: Extraction failed, skipping" >&2
+    ERROR_COUNT=$((ERROR_COUNT + 1))
+    continue
+  fi
+
+  action_count=$(jq '.summary.total_actions' "$extracted_file")
+  network_count=$(jq '.summary.total_network_calls' "$extracted_file")
+  echo "  Extracted: $action_count actions, $network_count network calls" >&2
+
+  # Step 2: Match to expectation
+  matched_id=$(match_expectation "$trace_name")
+  if [[ -n "$matched_id" ]]; then
+    expectation_json=$(echo "$EXPECTATIONS" | jq --arg id "$matched_id" '.expectations[] | select(.id == $id)')
+    echo "  Matched expectation: $matched_id" >&2
+  else
+    # No match — create a generic expectation asking the model to describe what it sees
+    echo "  No expectation match — using generic grading" >&2
+    expectation_json=$(jq -n \
+      --arg name "$trace_name" \
+      '{
+        id: "unmatched",
+        name: $name,
+        category: "unknown",
+        spec_section: "Unknown",
+        feature_area: "unknown",
+        expected_behavior: "Describe what this test demonstrates based on the trace evidence. Grade PASS if the test appears to exercise a meaningful feature successfully, WEAK if it runs but does not verify much, FAIL if it errors or demonstrates nothing.",
+        key_assertions: ["Test completes without errors", "At least one meaningful user action is performed", "Network calls return success status codes"],
+        ui_indicators: [],
+        network_indicators: []
+      }')
+  fi
+
+  # Step 3: Grade
+  verdict_file="$OUTPUT_DIR/verdicts/${trace_name%.zip}-verdict.json"
+  echo "  Grading..." >&2
+  if ! "$SCRIPT_DIR/grade-trace.sh" \
+    --trace-json "$(cat "$extracted_file")" \
+    --expectation-json "$expectation_json" \
+    > "$verdict_file" 2>/dev/null; then
+    echo "  ERROR: Grading failed" >&2
+    ERROR_COUNT=$((ERROR_COUNT + 1))
+    continue
+  fi
+
+  verdict=$(jq -r '.verdict' "$verdict_file")
+  confidence=$(jq -r '.confidence' "$verdict_file")
+  echo "  Verdict: $verdict (confidence: $confidence)" >&2
+
+  case "$verdict" in
+    PASS) PASS_COUNT=$((PASS_COUNT + 1)) ;;
+    WEAK) WEAK_COUNT=$((WEAK_COUNT + 1)) ;;
+    FAIL) FAIL_COUNT=$((FAIL_COUNT + 1)) ;;
+    *)    ERROR_COUNT=$((ERROR_COUNT + 1)) ;;
+  esac
+
+  VERDICTS+=("$verdict_file")
+  echo "" >&2
+done
+
+# Step 4: Compute composite score
+GRADED=$((PASS_COUNT + WEAK_COUNT + FAIL_COUNT))
+if [[ $GRADED -eq 0 ]]; then
+  echo "ERROR: No traces were successfully graded" >&2
+  exit 1
+fi
+
+# Score formula:
+#   PASS  = 1.0 points
+#   WEAK  = 0.4 points (feature works but test doesn't prove it well)
+#   FAIL  = 0.0 points
+#   Normalize to 0-100
+SCORE=$(echo "scale=1; ($PASS_COUNT * 100 + $WEAK_COUNT * 40) / $GRADED" | bc)
+
+# Coverage: unique feature areas with at least one PASS
+FEATURES_COVERED=$(cat "$OUTPUT_DIR/verdicts"/*-verdict.json 2>/dev/null | \
+  jq -s '[.[] | select(.verdict == "PASS") | .expectation_id | split("-")[0]] | unique | length' 2>/dev/null || echo 0)
+TOTAL_FEATURES=$(echo "$EXPECTATIONS" | jq '[.expectations[].feature_area] | unique | length')
+
+# Build the full report
+ALL_VERDICTS=$(cat "$OUTPUT_DIR/verdicts"/*-verdict.json 2>/dev/null | jq -s '.' || echo "[]")
+
+REPORT=$(jq -n \
+  --argjson verdicts "$ALL_VERDICTS" \
+  --argjson score "$SCORE" \
+  --argjson pass "$PASS_COUNT" \
+  --argjson weak "$WEAK_COUNT" \
+  --argjson fail "$FAIL_COUNT" \
+  --argjson errors "$ERROR_COUNT" \
+  --argjson graded "$GRADED" \
+  --argjson total_traces "${#TRACE_ZIPS[@]}" \
+  --argjson features_covered "$FEATURES_COVERED" \
+  --argjson total_features "$TOTAL_FEATURES" \
+  --arg generated_at "$(date -Iseconds)" \
+  '{
+    generated_at: $generated_at,
+    score: {
+      composite: $score,
+      max: 100,
+      formula: "PASS=1.0, WEAK=0.4, FAIL=0.0, normalized to 0-100"
+    },
+    summary: {
+      total_traces: $total_traces,
+      graded: $graded,
+      pass: $pass,
+      weak: $weak,
+      fail: $fail,
+      errors: $errors,
+      pass_rate_pct: (if $graded > 0 then (($pass * 100) / $graded | floor) else 0 end),
+      features_covered: $features_covered,
+      total_features: $total_features
+    },
+    verdicts: $verdicts,
+    concerns: [
+      $verdicts[] | select(.verdict == "WEAK" or .verdict == "FAIL") |
+      { expectation: .expectation_name, verdict: .verdict, issues: .concerns }
+    ]
+  }')
+
+REPORT_FILE="$OUTPUT_DIR/eval-report.json"
+echo "$REPORT" | jq '.' > "$REPORT_FILE"
+
+# Print summary to stderr
+echo "=== Eval Results ===" >&2
+echo "Score:    $SCORE / 100" >&2
+echo "PASS:     $PASS_COUNT" >&2
+echo "WEAK:     $WEAK_COUNT" >&2
+echo "FAIL:     $FAIL_COUNT" >&2
+echo "Errors:   $ERROR_COUNT" >&2
+echo "Coverage: $FEATURES_COVERED / $TOTAL_FEATURES feature areas" >&2
+echo "" >&2
+echo "Full report: $REPORT_FILE" >&2
+
+# Print concerns
+if [[ $(echo "$REPORT" | jq '.concerns | length') -gt 0 ]]; then
+  echo "" >&2
+  echo "=== Concerns ===" >&2
+  echo "$REPORT" | jq -r '.concerns[] | "  [\(.verdict)] \(.expectation): \(.issues[0] // "no details")"' >&2
+fi
+
+# Output report path (for piping into other scripts)
+echo "$REPORT_FILE"

--- a/scripts/evals/extract-master-list.sh
+++ b/scripts/evals/extract-master-list.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# extract-master-list.sh — Reverse-engineer test coverage from existing E2E test suite
+#
+# Reads all test files in Test/e2e/E2eTests/Tests/, extracts test method
+# signatures and code, then uses Claude to produce a structured master list
+# describing what each test proves.
+#
+# Usage: ./scripts/evals/extract-master-list.sh [--tests-dir DIR] [--output FILE]
+#
+# Output: master-list.json with the known test coverage baseline
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+TESTS_DIR="$REPO_ROOT/Test/e2e/E2eTests/Tests"
+OUTPUT_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --tests-dir) TESTS_DIR="$2"; shift 2 ;;
+    --output) OUTPUT_FILE="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ ! -d "$TESTS_DIR" ]]; then
+  echo "ERROR: Tests directory not found: $TESTS_DIR" >&2
+  exit 1
+fi
+
+# Step 1: Collect all test source code into a single document
+# Organized by page/category for the model to parse
+echo "Collecting test files from $TESTS_DIR..." >&2
+
+TEST_CODE=""
+TEST_COUNT=0
+
+for test_file in "$TESTS_DIR"/*/*.cs; do
+  [[ -f "$test_file" ]] || continue
+  relative_path="${test_file#$REPO_ROOT/}"
+  file_content=$(cat "$test_file")
+
+  # Skip files with no [Fact] attributes (empty test files)
+  if ! echo "$file_content" | grep -q '\[Fact\]'; then
+    continue
+  fi
+
+  method_count=$(echo "$file_content" | grep -c '\[Fact\]' || true)
+  TEST_COUNT=$((TEST_COUNT + method_count))
+
+  TEST_CODE+="
+=== FILE: $relative_path ===
+$file_content
+"
+done
+
+echo "Found $TEST_COUNT test methods across $(echo "$TEST_CODE" | grep -c '=== FILE:') files" >&2
+
+# Step 2: Also collect page model source for context
+PAGE_MODELS_DIR="$REPO_ROOT/Test/e2e/E2eTests/PageModels"
+PAGE_MODEL_CODE=""
+
+if [[ -d "$PAGE_MODELS_DIR" ]]; then
+  for pm_file in "$PAGE_MODELS_DIR"/*.cs; do
+    [[ -f "$pm_file" ]] || continue
+    relative_path="${pm_file#$REPO_ROOT/}"
+    PAGE_MODEL_CODE+="
+=== FILE: $relative_path ===
+$(cat "$pm_file")
+"
+  done
+fi
+
+# Step 3: Send to Claude for structured extraction
+PROMPT=$(cat <<'PROMPT_EOF'
+You are analyzing an existing E2E test suite to extract a master list of test coverage.
+
+Below are the test files and their page models. For each [Fact] test method, produce a JSON object describing what it tests.
+
+For each test, produce:
+```json
+{
+  "id": "page-category-NNN",
+  "test_class": "Tests.LoginPage.HappyPath",
+  "test_method": "UserCanSignIn_WithExistingCredentials",
+  "file": "Test/e2e/E2eTests/Tests/LoginPage/HappyPath.cs",
+  "category": "happy_path" | "validation" | "permissions" | "screenshots" | "multitenancy",
+  "feature_area": "auth" | "articles" | "editor" | "feed" | "profiles" | "settings" | "users" | "swagger" | "multitenancy",
+  "behavior_tested": "One sentence: what behavior this test verifies",
+  "key_verifications": ["List of specific things this test checks — derived from the Expect() and assert calls in the code"],
+  "pages_involved": ["LoginPage", "SettingsPage"],
+  "api_setup": ["CreateUserAsync", "InviteUserAsync"] or [],
+  "ui_actions": ["Navigate to /login", "Fill email", "Fill password", "Click Sign in"],
+  "requires_auth": true/false
+}
+```
+
+Rules:
+1. Every [Fact] method gets exactly one entry
+2. `key_verifications` must be derived from actual Expect()/assert calls in the code, not inferred
+3. `behavior_tested` should be concrete: "User can log in with valid credentials" not "Tests login"
+4. `category` is derived from the file: HappyPath.cs → happy_path, Validation.cs → validation, etc.
+5. `feature_area` is derived from the parent folder name
+6. IDs: use format "{feature_area}-{category}-{NNN}" (e.g., "auth-happy-001")
+7. Include ALL test methods — do not skip any
+
+Output ONLY the JSON array, no markdown fencing, no explanation.
+
+## Test Files
+
+PROMPT_EOF
+)
+
+echo "Sending to Claude for analysis..." >&2
+
+FULL_PROMPT="$PROMPT
+
+$TEST_CODE
+
+## Page Models (for context — these show what locators/actions are available)
+
+$PAGE_MODEL_CODE"
+
+RESULT=$(echo "$FULL_PROMPT" | claude -p --output-format json 2>/dev/null)
+
+# Extract text content from Claude response
+MASTER_LIST=$(echo "$RESULT" | jq -r '
+  if type == "array" then
+    map(select(.type == "text") | .text) | join("")
+  elif .result then
+    .result
+  elif .content then
+    if (.content | type) == "array" then
+      .content | map(select(.type == "text") | .text) | join("")
+    else
+      .content
+    end
+  else
+    tostring
+  end
+' 2>/dev/null || echo "$RESULT")
+
+# Validate JSON array
+if ! echo "$MASTER_LIST" | jq 'if type == "array" then . else error("not an array") end' >/dev/null 2>&1; then
+  MASTER_LIST=$(echo "$MASTER_LIST" | grep -o '\[.*\]' | head -1)
+  if ! echo "$MASTER_LIST" | jq '.' >/dev/null 2>&1; then
+    echo "ERROR: Failed to generate valid JSON master list" >&2
+    echo "Raw output saved to /tmp/master-list-raw.txt" >&2
+    echo "$RESULT" > /tmp/master-list-raw.txt
+    exit 1
+  fi
+fi
+
+# Add metadata wrapper
+ACTUAL_COUNT=$(echo "$MASTER_LIST" | jq 'length')
+FINAL=$(jq -n \
+  --argjson tests "$MASTER_LIST" \
+  --arg tests_dir "$TESTS_DIR" \
+  --arg generated_at "$(date -Iseconds)" \
+  --argjson expected_count "$TEST_COUNT" \
+  '{
+    generated_at: $generated_at,
+    source: $tests_dir,
+    expected_test_count: $expected_count,
+    actual_test_count: ($tests | length),
+    count_match: ($expected_count == ($tests | length)),
+    by_category: ($tests | group_by(.category) | map({(.[0].category): length}) | add),
+    by_feature: ($tests | group_by(.feature_area) | map({(.[0].feature_area): length}) | add),
+    tests: $tests
+  }')
+
+if [[ -n "$OUTPUT_FILE" ]]; then
+  echo "$FINAL" | jq '.' > "$OUTPUT_FILE"
+  echo "Wrote $ACTUAL_COUNT test descriptions to $OUTPUT_FILE (expected: $TEST_COUNT)" >&2
+  if [[ "$ACTUAL_COUNT" -ne "$TEST_COUNT" ]]; then
+    echo "WARNING: Count mismatch — model may have missed or duplicated some tests" >&2
+  fi
+else
+  echo "$FINAL" | jq '.'
+fi

--- a/scripts/evals/extract-trace.sh
+++ b/scripts/evals/extract-trace.sh
@@ -1,0 +1,248 @@
+#!/bin/bash
+# extract-trace.sh — Extract Playwright trace zip into structured JSON for model grading
+#
+# Playwright trace zips contain NDJSON files:
+#   trace.trace    — actions, DOM snapshots, console, screenshots
+#   trace.network  — network requests/responses
+#   resources/     — binary blobs (screenshots, DOM HTML, response bodies)
+#
+# Usage: ./scripts/evals/extract-trace.sh <trace.zip> [--screenshots-dir DIR]
+#
+# Output: JSON to stdout with { actions, network, dom_snapshots, console, screenshots, metadata }
+
+set -euo pipefail
+
+TRACE_ZIP="${1:?Usage: extract-trace.sh <trace.zip> [--screenshots-dir DIR]}"
+SCREENSHOTS_DIR=""
+
+shift || true
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --screenshots-dir) SCREENSHOTS_DIR="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ ! -f "$TRACE_ZIP" ]]; then
+  echo "ERROR: Trace file not found: $TRACE_ZIP" >&2
+  exit 1
+fi
+
+# Create temp dir for extraction
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Unzip trace
+unzip -q -o "$TRACE_ZIP" -d "$TMPDIR"
+
+# Find trace files — may be chunked (trace.trace, trace-chunk1.trace, etc.)
+# Use associative array to deduplicate (overlapping globs can match the same file)
+declare -A SEEN_TRACE SEEN_NETWORK
+TRACE_FILES=()
+for f in "$TMPDIR"/trace*.trace "$TMPDIR"/*-chunk*.trace; do
+  [[ -f "$f" && -z "${SEEN_TRACE[$f]:-}" ]] && TRACE_FILES+=("$f") && SEEN_TRACE[$f]=1
+done
+
+NETWORK_FILES=()
+for f in "$TMPDIR"/trace*.network "$TMPDIR"/*-chunk*.network; do
+  [[ -f "$f" && -z "${SEEN_NETWORK[$f]:-}" ]] && NETWORK_FILES+=("$f") && SEEN_NETWORK[$f]=1
+done
+
+# Extract actions (before/after pairs)
+extract_actions() {
+  for f in "${TRACE_FILES[@]}"; do
+    cat "$f"
+  done | jq -c 'select(.type == "before" or .type == "after")' 2>/dev/null | \
+  jq -s '
+    # Group by callId to pair before/after
+    group_by(.callId) |
+    map(
+      (map(select(.type == "before")) | first) as $before |
+      (map(select(.type == "after")) | first) as $after |
+      {
+        callId: ($before // $after).callId,
+        method: ($before.apiName // ($before.class + "." + $before.method)),
+        params: $before.params,
+        wallTime: $before.wallTime,
+        duration_ms: (if $after.endTime and $before.startTime then ($after.endTime - $before.startTime) else null end),
+        error: $after.error,
+        result_error: ($after.result.error // null),
+        passed: ($after.error == null and ($after.result.error // null) == null)
+      }
+    ) |
+    # Filter to interesting actions (skip internal playwright setup)
+    map(select(
+      .method != null and (
+        (.method | test("goto|click|fill|check|uncheck|press|selectOption|setInputFiles|tap|type|dispatch"; "i")) or
+        (.method | test("expect|assert"; "i")) or
+        (.method | test("page\\.goto|locator\\.|frame\\."; "i"))
+      )
+    ))
+  '
+}
+
+# Extract network requests
+extract_network() {
+  if [[ ${#NETWORK_FILES[@]} -eq 0 ]]; then
+    echo "[]"
+    return
+  fi
+
+  for f in "${NETWORK_FILES[@]}"; do
+    cat "$f"
+  done | jq -c '.' 2>/dev/null | jq -s '
+    map(
+      # Network entries may have different shapes depending on trace version
+      if .request then
+        {
+          method: .request.method,
+          url: .request.url,
+          status: (.response.status // null),
+          status_text: (.response.statusText // null),
+          request_headers: (.request.headers // []),
+          response_headers: (.response.headers // []),
+          resource_type: (.resourceType // null),
+          request_body_sha1: (.request.postData // null),
+          response_body_sha1: (.response.content.sha1 // null)
+        }
+      else
+        # resource-snapshot format
+        {
+          method: (.method // null),
+          url: (.url // null),
+          status: (.status // null),
+          resource_type: (.type // null)
+        }
+      end
+    ) |
+    # Filter to API calls (skip static assets)
+    map(select(
+      .url != null and (
+        (.url | test("/api/"; "i")) or
+        (.url | test("/identity/"; "i")) or
+        (.url | test("/dev-only/"; "i"))
+      )
+    ))
+  '
+}
+
+# Extract DOM snapshots — get visible text from frame-snapshot HTML resources
+extract_dom_snapshots() {
+  for f in "${TRACE_FILES[@]}"; do
+    cat "$f"
+  done | jq -c 'select(.type == "frame-snapshot")' 2>/dev/null | \
+  jq -s '
+    # Take a sample — every 5th snapshot to avoid overwhelming output
+    [to_entries[] | select(.key % 5 == 0) | .value] |
+    map({
+      snapshot_id: .callId,
+      wallTime: .wallTime,
+      sha1: .snapshot.sha1
+    })
+  ' | jq -c '.' 2>/dev/null || echo "[]"
+}
+
+# Extract console messages
+extract_console() {
+  for f in "${TRACE_FILES[@]}"; do
+    cat "$f"
+  done | jq -c 'select(.type == "console")' 2>/dev/null | jq -s '
+    map({
+      type: .messageType,
+      text: .text,
+      url: .url,
+      line: .lineNumber
+    }) |
+    # Only keep warnings and errors
+    map(select(.type == "warning" or .type == "error"))
+  '
+}
+
+# Extract metadata (context options, viewport, etc.)
+extract_metadata() {
+  for f in "${TRACE_FILES[@]}"; do
+    cat "$f"
+  done | jq -c 'select(.type == "context-options")' 2>/dev/null | head -1 | \
+  jq '{
+    viewport: .options.viewport,
+    userAgent: .options.userAgent,
+    baseURL: .options.baseURL,
+    isMobile: .options.isMobile,
+    hasTouch: .options.hasTouch
+  }' 2>/dev/null || echo "{}"
+}
+
+# Extract screenshots if requested
+extract_screenshots() {
+  if [[ -z "$SCREENSHOTS_DIR" ]]; then
+    echo "[]"
+    return
+  fi
+
+  mkdir -p "$SCREENSHOTS_DIR"
+
+  local screenshot_paths=()
+  for f in "${TRACE_FILES[@]}"; do
+    cat "$f"
+  done | jq -c 'select(.type == "screencast-frame")' 2>/dev/null | while IFS= read -r line; do
+    sha1=$(echo "$line" | jq -r '.sha1')
+    timestamp=$(echo "$line" | jq -r '.wallTime // .timestamp // "unknown"')
+    resource_file="$TMPDIR/resources/$sha1"
+    if [[ -f "$resource_file" ]]; then
+      out_file="$SCREENSHOTS_DIR/${timestamp}_${sha1}.jpeg"
+      cp "$resource_file" "$out_file"
+      echo "$out_file"
+    fi
+  done | jq -R -s 'split("\n") | map(select(length > 0))'
+}
+
+# Resolve DOM snapshot SHA1s to visible text
+resolve_dom_text() {
+  local snapshots="$1"
+  echo "$snapshots" | jq -c '.[]' | while IFS= read -r snap; do
+    sha1=$(echo "$snap" | jq -r '.sha1 // empty')
+    if [[ -n "$sha1" && -f "$TMPDIR/resources/$sha1" ]]; then
+      # Extract visible text from HTML — strip tags, collapse whitespace
+      visible_text=$(sed 's/<[^>]*>//g' "$TMPDIR/resources/$sha1" 2>/dev/null | \
+        tr '\n' ' ' | sed 's/  */ /g' | head -c 2000)
+      echo "$snap" | jq --arg text "$visible_text" '. + {visible_text: $text}'
+    else
+      echo "$snap"
+    fi
+  done | jq -s '.'
+}
+
+# Build the full extraction
+ACTIONS=$(extract_actions)
+NETWORK=$(extract_network)
+DOM_RAW=$(extract_dom_snapshots)
+DOM_SNAPSHOTS=$(resolve_dom_text "$DOM_RAW")
+CONSOLE=$(extract_console)
+METADATA=$(extract_metadata)
+SCREENSHOTS=$(extract_screenshots)
+
+# Compose final JSON
+jq -n \
+  --argjson actions "$ACTIONS" \
+  --argjson network "$NETWORK" \
+  --argjson dom_snapshots "$DOM_SNAPSHOTS" \
+  --argjson console "$CONSOLE" \
+  --argjson metadata "$METADATA" \
+  --argjson screenshots "$SCREENSHOTS" \
+  --arg source_file "$(basename "$TRACE_ZIP")" \
+  '{
+    source_file: $source_file,
+    metadata: $metadata,
+    actions: $actions,
+    network: $network,
+    dom_snapshots: $dom_snapshots,
+    console_messages: $console,
+    screenshots: $screenshots,
+    summary: {
+      total_actions: ($actions | length),
+      total_network_calls: ($network | length),
+      total_dom_snapshots: ($dom_snapshots | length),
+      total_console_warnings_errors: ($console | length),
+      failed_actions: ([$actions[] | select(.passed == false)] | length)
+    }
+  }'

--- a/scripts/evals/generate-expectations.sh
+++ b/scripts/evals/generate-expectations.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# generate-expectations.sh — Generate test expectations from SPEC-REFERENCE.md
+#
+# Reads the spec and produces expectations.json describing what each E2E test
+# case should demonstrate. This is the "ground truth" that traces are graded against.
+#
+# Usage: ./scripts/evals/generate-expectations.sh [--spec FILE] [--output FILE]
+#
+# Output: expectations.json with array of test expectations
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Defaults
+SPEC_FILE="$REPO_ROOT/SPEC-REFERENCE.md"
+OUTPUT_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --spec) SPEC_FILE="$2"; shift 2 ;;
+    --output) OUTPUT_FILE="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ ! -f "$SPEC_FILE" ]]; then
+  echo "ERROR: Spec file not found: $SPEC_FILE" >&2
+  exit 1
+fi
+
+PROMPT=$(cat <<'PROMPT_EOF'
+You are generating test expectations from an API specification. Read the spec below and produce a JSON array of test expectations.
+
+Each expectation describes ONE testable behavior that an E2E test should demonstrate. Group them by feature area (auth, profiles, articles, comments, favorites, feed, tags, settings, users).
+
+For each expectation, produce:
+
+```json
+{
+  "id": "auth-001",
+  "name": "UserCanRegisterAsFirstUser",
+  "category": "happy_path" | "validation" | "permissions",
+  "spec_section": "Authentication > Registration Flow",
+  "feature_area": "auth",
+  "expected_behavior": "First user registers via /register, gets 204, can then login and receives a JWT token. First user gets ADMIN + USER roles.",
+  "key_assertions": [
+    "POST /api/identity/register returns 204",
+    "POST /api/identity/login returns accessToken",
+    "User sees authenticated UI (settings link visible, sign-in link hidden)",
+    "Users nav item visible (user is ADMIN)"
+  ],
+  "ui_indicators": [
+    "Registration form accepts email + password",
+    "After login, sidebar shows Settings and Users links",
+    "Username displayed in navigation matches email"
+  ],
+  "network_indicators": [
+    "POST /api/identity/register → 204",
+    "POST /api/identity/login?useCookies=false → 200 with accessToken",
+    "GET /api/user → 200 with user object"
+  ],
+  "preconditions": "No existing users (fresh tenant)",
+  "data_setup": "none"
+}
+```
+
+Rules:
+1. Cover ALL endpoints and behaviors in the spec
+2. Include happy path, validation (bad input), and permissions (unauthorized access) cases
+3. `key_assertions` — what MUST be true for this test to be considered passing
+4. `ui_indicators` — what a human (or model) looking at screenshots/DOM would see
+5. `network_indicators` — what API calls should appear in the network trace
+6. Keep descriptions concrete and verifiable, not vague
+7. For validation cases, specify the exact error message or status code expected
+8. For permissions cases, specify what happens when an unauthorized user tries the action
+9. IDs should be sequential within each feature area (auth-001, auth-002, etc.)
+
+Output ONLY the JSON array, no markdown fencing, no explanation.
+
+Here is the spec:
+
+PROMPT_EOF
+)
+
+echo "Generating expectations from: $SPEC_FILE" >&2
+
+# Combine prompt with spec content
+FULL_PROMPT="$PROMPT
+
+$(cat "$SPEC_FILE")"
+
+# Call Claude to generate expectations
+RESULT=$(echo "$FULL_PROMPT" | claude -p --output-format json 2>/dev/null)
+
+# Extract the text content from Claude's response
+# Claude --output-format json wraps the response in a JSON envelope
+EXPECTATIONS=$(echo "$RESULT" | jq -r '
+  if type == "array" then
+    map(select(.type == "text") | .text) | join("")
+  elif .result then
+    .result
+  elif .content then
+    if (.content | type) == "array" then
+      .content | map(select(.type == "text") | .text) | join("")
+    else
+      .content
+    end
+  else
+    tostring
+  end
+' 2>/dev/null || echo "$RESULT")
+
+# Validate it's valid JSON array
+if ! echo "$EXPECTATIONS" | jq 'if type == "array" then . else error("not an array") end' >/dev/null 2>&1; then
+  # Try to extract JSON array from the response (model may have wrapped it in text)
+  EXPECTATIONS=$(echo "$EXPECTATIONS" | grep -o '\[.*\]' | head -1)
+  if ! echo "$EXPECTATIONS" | jq '.' >/dev/null 2>&1; then
+    echo "ERROR: Failed to generate valid JSON expectations" >&2
+    echo "Raw output saved to /tmp/expectations-raw.txt" >&2
+    echo "$RESULT" > /tmp/expectations-raw.txt
+    exit 1
+  fi
+fi
+
+# Add metadata
+FINAL=$(jq -n \
+  --argjson expectations "$EXPECTATIONS" \
+  --arg spec_file "$(basename "$SPEC_FILE")" \
+  --arg generated_at "$(date -Iseconds)" \
+  '{
+    generated_at: $generated_at,
+    spec_file: $spec_file,
+    total_expectations: ($expectations | length),
+    by_category: ($expectations | group_by(.category) | map({(.[0].category): length}) | add),
+    by_feature: ($expectations | group_by(.feature_area) | map({(.[0].feature_area): length}) | add),
+    expectations: $expectations
+  }')
+
+if [[ -n "$OUTPUT_FILE" ]]; then
+  echo "$FINAL" | jq '.' > "$OUTPUT_FILE"
+  echo "Wrote $(echo "$FINAL" | jq '.total_expectations') expectations to $OUTPUT_FILE" >&2
+else
+  echo "$FINAL" | jq '.'
+fi

--- a/scripts/evals/generate-expectations.sh
+++ b/scripts/evals/generate-expectations.sh
@@ -31,9 +31,11 @@ if [[ ! -f "$SPEC_FILE" ]]; then
 fi
 
 PROMPT=$(cat <<'PROMPT_EOF'
-You are generating test expectations from an API specification. Read the spec below and produce a JSON array of test expectations.
+You are generating E2E test expectations from a full-stack application specification. The spec contains BOTH API endpoints AND frontend UI behaviors. Read the ENTIRE spec and produce a JSON array of test expectations.
 
-Each expectation describes ONE testable behavior that an E2E test should demonstrate. Group them by feature area (auth, profiles, articles, comments, favorites, feed, tags, settings, users).
+These expectations are used to grade Playwright E2E test traces. They describe what a test should demonstrate from the user's perspective in the browser, backed by network evidence.
+
+Each expectation describes ONE testable behavior. Group by feature area: auth, profiles, articles, comments, favorites, feed, tags, settings, users, dashboard, mobile, multitenancy, swagger, editor.
 
 For each expectation, produce:
 
@@ -41,7 +43,7 @@ For each expectation, produce:
 {
   "id": "auth-001",
   "name": "UserCanRegisterAsFirstUser",
-  "category": "happy_path" | "validation" | "permissions",
+  "category": "happy_path" | "validation" | "permissions" | "screenshots",
   "spec_section": "Authentication > Registration Flow",
   "feature_area": "auth",
   "expected_behavior": "First user registers via /register, gets 204, can then login and receives a JWT token. First user gets ADMIN + USER roles.",
@@ -67,15 +69,26 @@ For each expectation, produce:
 ```
 
 Rules:
-1. Cover ALL endpoints and behaviors in the spec
-2. Include happy path, validation (bad input), and permissions (unauthorized access) cases
-3. `key_assertions` — what MUST be true for this test to be considered passing
-4. `ui_indicators` — what a human (or model) looking at screenshots/DOM would see
-5. `network_indicators` — what API calls should appear in the network trace
+1. COMPREHENSIVENESS IS CRITICAL. Cover ALL endpoints AND ALL frontend UI behaviors in the spec. Do not skip any section. Every API endpoint, every UI behavior bullet point, every screenshot test, every validation scenario must have at least one expectation.
+2. Include happy_path, validation, permissions, and screenshots categories
+3. `key_assertions` — what MUST be true for this test to pass. Include BOTH:
+   - UI-level assertions: DOM state, visible text, URL changes, error messages displayed, elements visible/hidden
+   - API-level assertions: status codes, response fields (these support the UI assertions)
+4. `ui_indicators` — what a human looking at screenshots/DOM would see. Be specific: name the exact text, link, button, or element.
+5. `network_indicators` — API calls that should appear in the network trace
 6. Keep descriptions concrete and verifiable, not vague
-7. For validation cases, specify the exact error message or status code expected
-8. For permissions cases, specify what happens when an unauthorized user tries the action
-9. IDs should be sequential within each feature area (auth-001, auth-002, etc.)
+7. For validation cases: include BOTH the API response (e.g., "returns 400") AND the UI outcome (e.g., "error message is displayed in the DOM"). Both matter.
+8. For permissions/redirect cases: include BOTH the API response (e.g., "returns 401") AND the frontend behavior (e.g., "browser URL changes to /login").
+9. For frontend-only behaviors (mobile layout, tag input UI, pagination navigation, feature flags, i18n): there may be NO network indicators — that's fine. The key assertions are purely UI-based.
+10. IDs should be sequential within each feature area (auth-001, auth-002, etc.)
+11. Do NOT collapse multiple distinct behaviors into one expectation. Each separately testable behavior gets its own entry.
+12. Generate SEPARATE expectations for:
+    - Each distinct validation scenario (duplicate email vs duplicate username are separate)
+    - Each settings field validation (duplicate username on settings page vs duplicate email on settings page are separate)
+    - Each screenshot/visual regression test mentioned in the spec
+    - Each mobile-specific behavior
+    - Each protected route redirect
+    - Viewing own profile vs viewing another user's profile
 
 Output ONLY the JSON array, no markdown fencing, no explanation.
 

--- a/scripts/evals/generate-spec.prompt.md
+++ b/scripts/evals/generate-spec.prompt.md
@@ -1,0 +1,141 @@
+# Prompt: Generate Full-Stack Application Specification
+
+Use this prompt with a model that has access to the full codebase. The goal is to produce a single specification document that covers BOTH backend API behavior AND frontend UI behavior in enough detail to generate E2E test expectations from it.
+
+---
+
+## The Prompt
+
+You are generating a complete application specification by reading the codebase. This spec will be used to:
+1. Generate E2E test expectations (what Playwright tests should verify)
+2. Grade test traces (did the test actually demonstrate what it claims?)
+3. Audit test coverage (are all specified behaviors covered by tests?)
+
+The spec must describe the application from TWO perspectives:
+- **API perspective:** Every endpoint, its inputs, outputs, status codes, validation rules, and business logic
+- **User perspective:** Every UI flow, page behavior, navigation pattern, error display, responsive layout, and visual state
+
+Both perspectives are equally important. A spec that only covers APIs will miss frontend-only behaviors (route guards, mobile layout, i18n, feature flags, pagination UI). A spec that only covers UI flows will miss validation edge cases and error formats.
+
+### Step 1: Discover the application structure
+
+Read these locations to understand what exists:
+
+**Backend:**
+- Route/endpoint definitions (controllers, endpoint classes, route registrations)
+- Request/response DTOs and data models
+- Validation rules (FluentValidation, data annotations, manual checks)
+- Authentication/authorization configuration
+- Database entities and their constraints (field lengths, required fields, unique constraints)
+- Business rules (ordering, defaults, idempotency, error handling)
+- Middleware (error handling, tenant resolution, feature flags)
+
+**Frontend:**
+- Router configuration (all routes, route guards, protected routes, redirects)
+- Page components (what each page renders, forms, tables, modals)
+- Navigation structure (sidebar, header, mobile hamburger menu)
+- Responsive behavior (mobile breakpoints, layout changes, touch interactions)
+- Feature flags (which features are gated, what changes when toggled)
+- Internationalization (supported languages, what gets translated)
+- Error handling (how API errors are displayed to the user, toast/inline/page-level)
+- State management (authentication state, how login/logout affects the UI)
+
+**Tests (as specification evidence):**
+- E2E tests reveal UI behaviors the developer considered important
+- API/integration tests reveal validation edge cases and error formats
+- Test fixtures reveal data setup patterns and preconditions
+
+### Step 2: Write the specification
+
+Organize the spec into these sections:
+
+#### Overview
+- What the application does (one paragraph)
+- Tech stack summary
+- Key differences from standard/expected behavior (non-obvious API choices, custom auth flows)
+
+#### Base URL & Conventions
+- URL structure, content types, common headers
+- Authentication mechanism (token format, header name, how tokens are obtained)
+
+#### Error Response Format
+- All error response shapes the API can return
+- How validation errors are structured
+- Status code semantics (when 400 vs 401 vs 403 vs 404)
+
+#### Endpoints (one section per resource group)
+For EACH endpoint, document:
+- Method, path, auth requirements
+- Request body schema with field constraints (required, min/max length, format)
+- Success response with example JSON
+- Every error response with the exact condition that triggers it
+- Business rules (idempotency, side effects, ordering, defaults)
+- Test assertions (what the tests actually check — this reveals edge cases)
+
+#### Frontend UI Behaviors
+This section is CRITICAL and most often missing from specs. Document:
+
+**Navigation & Layout:**
+- What links/items appear in navigation for different user roles
+- What happens when a role-restricted item is accessed by the wrong role
+
+**Route Guards (Frontend Redirects):**
+- Every protected route and where it redirects unauthenticated users
+- This is DIFFERENT from the API returning 401 — the frontend prevents the request entirely
+
+**Mobile Responsive Behavior:**
+- What changes at mobile viewport sizes
+- Hamburger menu behavior (open, close, auto-close on navigation)
+- Touch-specific interactions
+
+**Page-Specific Behaviors:**
+For each page, document behaviors that aren't covered by API docs:
+- Default tab/state on page load
+- How API errors are rendered (inline messages, toasts, redirect to error page)
+- Pagination UI (when controls appear, how navigation works, edge cases with few items)
+- Form interactions (tag input chips, auto-submit on certain keys, pre-population on edit)
+- Feature flag gated content (what appears/disappears when flags toggle)
+
+**Authentication UI Flows:**
+- Registration → login → authenticated state (what changes in the UI)
+- Login error display (how failed login is shown — not just the 401, the visible error)
+- Sign out behavior (redirect target, UI state change)
+- Invite flow (admin invites user, signs out, invited user signs in)
+
+**Admin/Management Pages:**
+- Table layouts, columns, pagination
+- Modal dialogs (edit roles, confirm actions)
+- Self-protection rules rendered in UI (can't deactivate self, can't remove own admin role)
+
+**Internationalization:**
+- How language is changed
+- What elements are translated (nav, titles, messages, form labels)
+
+**Screenshots / Visual Regression:**
+- List every distinct page/state that should have a visual regression test
+- Include mobile viewport states separately from desktop
+
+#### Data Models
+- All entities with field constraints
+- Request/response DTOs
+- Default values
+
+#### Business Rules
+- Cross-cutting rules (multi-tenancy isolation, ordering, pagination defaults)
+- Authorization matrix (who can modify/delete what)
+
+### Step 3: Self-check
+
+After writing the spec, verify:
+
+1. **Every route in the router config has at least one spec entry** (API endpoint or frontend redirect)
+2. **Every form has its validation rules documented** (both API-level and UI-level error display)
+3. **Every page mentioned in E2E tests is described** in the Frontend UI Behaviors section
+4. **Every error response has a corresponding UI behavior** (how does the user see this error?)
+5. **Mobile behavior is documented separately** from desktop (responsive is not automatic — interactions differ)
+6. **Feature flags are documented** with both enabled and disabled states
+7. **Screenshot test subjects are enumerated** individually (not "various pages" — list each one)
+
+### Output format
+
+Write the spec as a single Markdown document. Use tables for endpoint summaries, code blocks for JSON examples, and bullet lists for behavioral rules. The document should be self-contained — a reader (human or model) should be able to understand every testable behavior without accessing the codebase.

--- a/scripts/evals/grade-trace.sh
+++ b/scripts/evals/grade-trace.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# grade-trace.sh — Grade a single extracted trace against its expectation
+#
+# Takes the JSON output of extract-trace.sh and an expectation object,
+# sends both to Claude for independent grading.
+#
+# Usage: ./scripts/evals/grade-trace.sh <extracted-trace.json> <expectation.json>
+#    or: ./scripts/evals/grade-trace.sh --trace-json <json> --expectation-json <json>
+#
+# Output: JSON verdict to stdout
+
+set -euo pipefail
+
+TRACE_JSON=""
+EXPECTATION_JSON=""
+TRACE_FILE=""
+EXPECTATION_FILE=""
+
+# Parse args
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --trace-json) TRACE_JSON="$2"; shift 2 ;;
+    --expectation-json) EXPECTATION_JSON="$2"; shift 2 ;;
+    *)
+      if [[ -z "$TRACE_FILE" ]]; then
+        TRACE_FILE="$1"; shift
+      elif [[ -z "$EXPECTATION_FILE" ]]; then
+        EXPECTATION_FILE="$1"; shift
+      else
+        echo "Unknown argument: $1" >&2; exit 1
+      fi
+      ;;
+  esac
+done
+
+# Load from files if not passed inline
+if [[ -z "$TRACE_JSON" && -n "$TRACE_FILE" ]]; then
+  TRACE_JSON=$(cat "$TRACE_FILE")
+fi
+if [[ -z "$EXPECTATION_JSON" && -n "$EXPECTATION_FILE" ]]; then
+  EXPECTATION_JSON=$(cat "$EXPECTATION_FILE")
+fi
+
+if [[ -z "$TRACE_JSON" || -z "$EXPECTATION_JSON" ]]; then
+  echo "ERROR: Both trace and expectation JSON are required" >&2
+  echo "Usage: grade-trace.sh <trace.json> <expectation.json>" >&2
+  exit 1
+fi
+
+# Build the grading prompt
+PROMPT=$(cat <<'PROMPT_EOF'
+You are an independent evaluator grading a Playwright E2E test trace against a spec expectation.
+
+You will receive:
+1. A TEST EXPECTATION — what this test is supposed to demonstrate
+2. A PLAYWRIGHT TRACE — the actual sequence of actions, network requests, DOM snapshots, and console messages from the test run
+
+Your job: determine whether the trace ACTUALLY demonstrates what the expectation claims. The test may have passed mechanically but still be wrong (weak assertions, testing the wrong thing, checking stale state).
+
+## Grading rules
+
+- **PASS**: The trace demonstrates ALL key assertions from the expectation. Every important behavior is both performed AND verified. Network calls confirm the backend responded correctly. DOM/UI indicators match what's expected.
+
+- **WEAK**: The feature *appears* to work (network calls succeed, DOM looks right) but the test doesn't fully verify the key claims. Examples:
+  - Checks visibility of an element but not its content
+  - Doesn't verify the correct API response status/body
+  - Asserts navigation happened but not that the right data is displayed
+  - Missing assertions for some key_assertions items
+
+- **FAIL**: The trace does NOT demonstrate the expected behavior. Examples:
+  - Actions don't match the expected flow
+  - API returned error status codes
+  - DOM doesn't show expected content
+  - Console has errors that indicate failure
+  - Test errored out or timed out
+
+## Focus on evidence
+
+Look at what the trace data ACTUALLY shows:
+- Do the actions match the expected user flow?
+- Do the network requests match network_indicators? Are status codes correct?
+- Do DOM snapshots contain the expected ui_indicators text?
+- Are there console errors that suggest something broke?
+- Did any actions fail (passed: false)?
+
+A test that mechanically passes but has weak evidence gets WEAK, not PASS.
+
+## Output format
+
+Respond with ONLY a JSON object (no markdown fencing):
+
+{
+  "verdict": "PASS" | "WEAK" | "FAIL",
+  "confidence": 0.0 to 1.0,
+  "demonstrated": ["list of key_assertions that ARE demonstrated by the trace"],
+  "not_demonstrated": ["list of key_assertions that are NOT demonstrated"],
+  "concerns": ["any issues: weak assertions, missing checks, timing problems, console errors"],
+  "evidence": {
+    "actions_match": true/false,
+    "network_match": true/false,
+    "ui_match": true/false,
+    "no_errors": true/false
+  },
+  "reasoning": "One paragraph explaining the verdict"
+}
+PROMPT_EOF
+)
+
+# Truncate trace data if too large (keep under ~50k chars to avoid context issues)
+TRACE_TRIMMED=$(echo "$TRACE_JSON" | jq '{
+  source_file: .source_file,
+  metadata: .metadata,
+  summary: .summary,
+  actions: (.actions[:50]),
+  network: (.network[:30]),
+  dom_snapshots: (.dom_snapshots[:10]),
+  console_messages: .console_messages
+}')
+
+FULL_PROMPT=$(cat <<EOF
+$PROMPT
+
+## TEST EXPECTATION
+
+$EXPECTATION_JSON
+
+## PLAYWRIGHT TRACE
+
+$TRACE_TRIMMED
+EOF
+)
+
+# Call Claude for grading
+RESULT=$(echo "$FULL_PROMPT" | claude -p --output-format json 2>/dev/null)
+
+# Extract the text content
+VERDICT=$(echo "$RESULT" | jq -r '
+  if type == "array" then
+    map(select(.type == "text") | .text) | join("")
+  elif .result then
+    .result
+  elif .content then
+    if (.content | type) == "array" then
+      .content | map(select(.type == "text") | .text) | join("")
+    else
+      .content
+    end
+  else
+    tostring
+  end
+' 2>/dev/null || echo "$RESULT")
+
+# Validate it's valid JSON
+if ! echo "$VERDICT" | jq '.' >/dev/null 2>&1; then
+  # Try to extract JSON object from response
+  VERDICT=$(echo "$VERDICT" | grep -o '{.*}' | head -1)
+  if ! echo "$VERDICT" | jq '.' >/dev/null 2>&1; then
+    # Return a structured error
+    jq -n \
+      --arg raw "$RESULT" \
+      '{
+        verdict: "ERROR",
+        confidence: 0,
+        demonstrated: [],
+        not_demonstrated: [],
+        concerns: ["Failed to parse grading model response"],
+        evidence: { actions_match: null, network_match: null, ui_match: null, no_errors: null },
+        reasoning: "Grading model returned unparseable response",
+        raw_response: ($raw | .[0:500])
+      }'
+    exit 0
+  fi
+fi
+
+# Add the expectation ID to the verdict for cross-referencing
+EXPECTATION_ID=$(echo "$EXPECTATION_JSON" | jq -r '.id // "unknown"')
+EXPECTATION_NAME=$(echo "$EXPECTATION_JSON" | jq -r '.name // "unknown"')
+
+echo "$VERDICT" | jq \
+  --arg id "$EXPECTATION_ID" \
+  --arg name "$EXPECTATION_NAME" \
+  '. + { expectation_id: $id, expectation_name: $name }'

--- a/scripts/evals/lint-spec.sh
+++ b/scripts/evals/lint-spec.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# lint-spec.sh — Structural completeness check for SPEC-REFERENCE.md
+#
+# Deterministic (no LLM call). Checks that required sections and patterns
+# exist in the spec. Catches the categories that caused eval coverage gaps.
+#
+# Usage: ./scripts/evals/lint-spec.sh [--spec FILE]
+# Exit code: 0 = pass, 1 = failures found
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SPEC_FILE="${1:-$REPO_ROOT/SPEC-REFERENCE.md}"
+
+if [[ "${1:-}" == "--spec" ]]; then
+  SPEC_FILE="${2:-$REPO_ROOT/SPEC-REFERENCE.md}"
+fi
+
+if [[ ! -f "$SPEC_FILE" ]]; then
+  echo "ERROR: Spec file not found: $SPEC_FILE" >&2
+  exit 1
+fi
+
+FAILURES=0
+WARNINGS=0
+SPEC=$(cat "$SPEC_FILE")
+
+pass() { echo "  PASS  $1"; }
+fail() { echo "  FAIL  $1"; FAILURES=$((FAILURES + 1)); }
+warn() { echo "  WARN  $1"; WARNINGS=$((WARNINGS + 1)); }
+
+check_section() {
+  local heading="$1"
+  local description="$2"
+  if echo "$SPEC" | grep -qi "$heading"; then
+    pass "$description"
+  else
+    fail "$description — missing section matching '$heading'"
+  fi
+}
+
+check_pattern() {
+  local pattern="$1"
+  local description="$2"
+  local min_count="${3:-1}"
+  local count
+  count=$(echo "$SPEC" | grep -ci "$pattern" || true)
+  if [[ "$count" -ge "$min_count" ]]; then
+    pass "$description ($count found)"
+  else
+    fail "$description — expected at least $min_count, found $count"
+  fi
+}
+
+echo "=== Spec Structural Lint: $(basename "$SPEC_FILE") ==="
+echo ""
+
+# --- Required top-level sections ---
+echo "--- Required Sections ---"
+check_section "## Overview"                    "Overview section"
+check_section "## Base URL"                    "Base URL & Conventions"
+check_section "## Error Response"              "Error Response Format"
+check_section "## Endpoints"                   "At least one Endpoints section"
+check_section "## Data Models"                 "Data Models section"
+check_section "## Business Rules"              "Business Rules section"
+check_section "## Frontend UI Behaviors"       "Frontend UI Behaviors section"
+
+echo ""
+
+# --- Frontend UI subsections ---
+echo "--- Frontend UI Subsections ---"
+check_section "### Navigation"                 "Navigation & Layout"
+check_section "### Route Guards"               "Route Guards (Frontend Redirects)"
+check_section "### Mobile"                     "Mobile Responsive Behavior"
+check_section "### Screenshots"                "Screenshots / Visual Regression"
+
+echo ""
+
+# --- Frontend behavior patterns ---
+echo "--- Frontend Behavior Coverage ---"
+check_pattern "/login"                         "Login redirect references" 3
+check_pattern "error.*message.*display\|display.*error\|visible.*error\|error.*visible\|error.*UI\|UI.*error" \
+                                               "UI error display descriptions" 3
+check_pattern "mobile\|375\|hamburger\|sidebar.*hidden\|responsive" \
+                                               "Mobile-specific behavior descriptions" 3
+check_pattern "screenshot\|visual regression"  "Screenshot/visual regression entries" 3
+check_pattern "feature.flag\|feature flag"     "Feature flag references" 1
+
+echo ""
+
+# --- API completeness signals ---
+echo "--- API Completeness ---"
+check_pattern "## Endpoint"                    "Endpoint group sections" 3
+check_pattern "Auth.*Required\|Auth.*Bearer\|Auth.*Not required" \
+                                               "Auth requirement declarations" 5
+check_pattern "Success Response\|200 OK\|201 Created\|204 No Content" \
+                                               "Success response examples" 5
+check_pattern "Error Response\|400 Bad\|401 Unauthorized\|403 Forbidden\|404 Not Found" \
+                                               "Error response documentation" 5
+check_pattern "Validation Rules\|required.*not empty\|min.*length\|max.*length" \
+                                               "Validation rule declarations" 3
+
+echo ""
+
+# --- Dual-perspective checks ---
+echo "--- Dual-Perspective (API + UI) ---"
+
+# Check that redirect behaviors mention browser/frontend, not just API 401
+redirect_mentions=$(echo "$SPEC" | grep -ci "redirect.*login\|browser.*url\|frontend.*redirect\|route guard" || true)
+api_only_auth=$(echo "$SPEC" | grep -ci "401 Unauthorized" || true)
+if [[ "$redirect_mentions" -ge 3 ]]; then
+  pass "Frontend redirect behaviors documented ($redirect_mentions references)"
+else
+  if [[ "$api_only_auth" -ge 3 ]]; then
+    warn "Found $api_only_auth API auth references but only $redirect_mentions frontend redirect descriptions — spec may be API-only for auth"
+  else
+    fail "Missing frontend redirect behavior documentation"
+  fi
+fi
+
+# Check that validation errors describe UI display, not just status codes
+ui_error_display=$(echo "$SPEC" | grep -ci "error.*displayed\|error.*visible\|displays.*error\|shows.*error\|message.*DOM\|visible.*user" || true)
+if [[ "$ui_error_display" -ge 3 ]]; then
+  pass "UI error display behaviors documented ($ui_error_display references)"
+else
+  warn "Only $ui_error_display UI error display descriptions — validation errors may only describe API status codes"
+fi
+
+# Check for pagination UI (not just API limit/offset)
+pagination_ui=$(echo "$SPEC" | grep -ci "pagination.*click\|pagination.*navigat\|page.*number\|pagination.*control\|pagination.*render" || true)
+pagination_api=$(echo "$SPEC" | grep -ci "limit.*offset\|offset.*limit" || true)
+if [[ "$pagination_ui" -ge 2 ]]; then
+  pass "Pagination UI behavior documented ($pagination_ui references)"
+else
+  if [[ "$pagination_api" -ge 2 ]]; then
+    warn "Found $pagination_api API pagination references but only $pagination_ui UI pagination descriptions"
+  fi
+fi
+
+echo ""
+
+# --- Summary ---
+echo "=== Summary ==="
+TOTAL=$((FAILURES + WARNINGS))
+if [[ "$FAILURES" -eq 0 && "$WARNINGS" -eq 0 ]]; then
+  echo "All checks passed."
+elif [[ "$FAILURES" -eq 0 ]]; then
+  echo "$WARNINGS warning(s), 0 failures."
+else
+  echo "$FAILURES failure(s), $WARNINGS warning(s)."
+fi
+
+exit "$FAILURES"


### PR DESCRIPTION
## Summary
- Adds three-layer trace-based eval infrastructure: Playwright trace extraction, LLM-based trace grading, and coverage analysis
- Introduces `[TestCoverage]` attribute with E2E008 Roslyn analyzer enforcing it on every `[Fact]` method
- Adds `PLAYWRIGHT_ALWAYS_TRACE` env var support to record traces for all tests (not just failures)
- Adds 4 eval Nuke targets: `TestEvalsGenerate`, `TestEvalsMasterList`, `TestEvalsCoverage`, `TestEvals`
- Adds `LintSpecVerify` Nuke target (wired into `LintAllVerify`) — deterministic spec completeness checks
- Adds `.claude/rules/spec-writing.md` — auto-loaded spec authoring checklist
- Adds `scripts/evals/generate-spec.prompt.md` — prompt for spec generation eval experiments
- Expands `SPEC-REFERENCE.md` with Frontend UI Behaviors section (route guards, mobile, dashboard, i18n, admin pages, screenshots)
- Tunes `generate-expectations.sh` prompt for dual-perspective (API + UI) expectation generation
- Annotates all existing E2E tests with `[TestCoverage(Id, FeatureArea, Behavior, Verifies)]`

## What problem does this solve?

Tests verify that code behaves correctly — but what verifies that the tests themselves are good? A test can pass mechanically while proving almost nothing (e.g. checking a page loaded without verifying its content). This is especially problematic with model-generated tests, which have an incentive to pass, not to catch bugs.

The eval system adds an independent observational layer: a model watches what *actually happened* during each test (via Playwright traces) and judges whether the test genuinely demonstrated what it claims.

## Architecture

There are three layers:

| Layer | What it does | Grounded in |
|-------|-------------|-------------|
| **Layer 1** — Test execution | Playwright tests run, pass/fail mechanically | Assertion logic |
| **Layer 2** — Trace grading | Independent model examines trace evidence (actions, network, DOM, screenshots) and grades PASS/WEAK/FAIL | Raw observation |
| **Layer 3** — Coverage check | Compares generated expectations against master list extracted from existing tests | Hand-written test suite |

The key insight: Layer 2's failure mode (model misreads evidence) is **independent** of Layer 1's failure mode (wrong assertions). A test with weak assertions but working code passes Layer 1 but gets graded WEAK by Layer 2.

## Spec quality as the bottleneck

Layer 3 revealed that **spec completeness drives expectation quality**. An API-only spec scored 33.9/100 on coverage. Through iterative improvement:

| Iteration | Score | Covered | Weak | Missing | Change |
|-----------|-------|---------|------|---------|--------|
| API-only spec | 33.9 | 21/81 | 13 | 47 | baseline |
| + Frontend UI behaviors | 93.8 | 72/81 | 8 | 1 | spec content |
| + Strengthened language | 95.6 | 75/81 | 5 | 1 | spec clarity |
| + Tuned generator prompt | 92.5 | 75/81 | 0 | 6 | prompt (traded coverage for precision) |
| + Balanced prompt + spec details | **98.7** | **79/81** | **2** | **0** | final |

This led to three artifacts for maintaining spec quality:
- **`LintSpecVerify`** — deterministic structural checks (no LLM, <1s)
- **`.claude/rules/spec-writing.md`** — auto-loaded checklist when editing specs
- **`scripts/evals/generate-spec.prompt.md`** — for "generate spec from scratch" eval experiments

## How to use

### Spec quality (run first)

```bash
# Lint spec for structural completeness (fast, no LLM)
./build.sh LintSpecVerify --agent
```

### Eval targets

```bash
# Generate expectations from spec (once, or when spec changes)
./build.sh TestEvalsGenerate --agent

# Extract master list from existing test suite (once, or when tests change)
./build.sh TestEvalsMasterList --agent

# Check that generated expectations cover all known tests (Layer 3)
./build.sh TestEvalsCoverage --agent

# Full eval: run E2E with tracing + grade all traces (Layer 2)
./build.sh TestEvals --agent
```

| Target | What it does | When to run |
|--------|-------------|-------------|
| `LintSpecVerify` | Structural completeness check on spec (no LLM) | Before generating expectations |
| `TestEvalsGenerate` | Reads `SPEC-REFERENCE.md`, calls Claude to produce `expectations.json` | Once, or when spec changes |
| `TestEvalsMasterList` | Parses `[TestCoverage]` attributes from test source files into `master-list.json` (no LLM, deterministic) | Once, or when E2E tests change |
| `TestEvalsCoverage` | Asserts `expectations.json ⊇ master-list.json` — **fails** if gaps exist | After generating both files |
| `TestEvals` | Runs E2E with always-on tracing, extracts traces, grades each against expectations | Full eval run |

### Shell scripts (for debugging or custom pipelines)

```bash
# Lint the spec
./scripts/evals/lint-spec.sh

# Extract a single Playwright trace to JSON
./scripts/evals/extract-trace.sh path/to/trace.zip > extracted.json

# Grade a single trace against an expectation
./scripts/evals/grade-trace.sh extracted.json expectation.json

# Run full pipeline on a directory of traces
./scripts/evals/eval-traces.sh \
  Reports/Test/e2e/Artifacts/ \
  Reports/Test/Evals/expectations.json \
  --output Reports/Test/Evals/Results/

# Generate expectations from spec
./scripts/evals/generate-expectations.sh \
  --spec SPEC-REFERENCE.md \
  --output Reports/Test/Evals/expectations.json

# Extract master list from test source
./scripts/evals/extract-master-list.sh

# Check coverage completeness
./scripts/evals/eval-coverage.sh \
  Reports/Test/Evals/expectations.json \
  Reports/Test/Evals/master-list.json
```

### Calibration (verify the eval system itself)

```bash
# Generate synthetic traces for known scenarios
./scripts/evals/create-test-trace.sh /tmp/calibration/ --scenario good
./scripts/evals/create-test-trace.sh /tmp/calibration/ --scenario weak
./scripts/evals/create-test-trace.sh /tmp/calibration/ --scenario bad

# Grade each — expect: good→PASS, weak→WEAK, bad→FAIL
./scripts/evals/eval-traces.sh /tmp/calibration/ expectations.json
```

## Verdicts

| Verdict | Meaning | Score |
|---------|---------|-------|
| **PASS** | Trace demonstrates ALL key assertions. Actions, network, and UI evidence confirm the feature works and the test verifies it. | 1.0 |
| **WEAK** | Feature appears to work but the test doesn't fully verify it. A broken app could also pass this test. | 0.4 |
| **FAIL** | Trace does not demonstrate expected behavior. Errors, wrong status codes, timeouts, or missing actions. | 0.0 |

**WEAK is the most valuable signal** — it catches tests that provide false confidence.

## Output

All output goes to `Reports/Test/Evals/`:

| File | Contents |
|------|----------|
| `expectations.json` | Generated from spec (Layer 2 + 3 input) |
| `master-list.json` | Extracted from existing tests (Layer 3 input) |
| `coverage-report.json` | Layer 3 results (gaps, weak coverage) |
| `Results/eval-report.json` | Layer 2 results (trace verdicts + composite score) |
| `Results/extracted/` | Per-trace extracted JSON |
| `Results/verdicts/` | Per-trace grading verdicts |

## `[TestCoverage]` attribute

Every `[Fact]` in the E2E test suite must have a `[TestCoverage]` attribute (enforced by E2E008 analyzer):

```csharp
[Fact]
[TestCoverage(
    Id = "auth-happy-001",
    FeatureArea = "auth",
    Behavior = "User can log in with valid credentials and see authenticated UI state",
    Verifies = ["Settings link visible in sidebar", "User profile link shows email"])]
public async Task UserCanSignIn_WithExistingCredentials()
```

ID format: `{area}-{category}-{NNN}` (e.g. `auth-happy-001`, `users-permissions-003`)

## Files added/modified

| File | Purpose |
|------|---------|
| `Docs/evals.md` | Full eval system documentation |
| `SPEC-REFERENCE.md` | Added Frontend UI Behaviors section |
| `.claude/rules/spec-writing.md` | Spec authoring checklist (auto-loaded) |
| `scripts/evals/*.sh` | 7 eval shell scripts + README |
| `scripts/evals/generate-spec.prompt.md` | Prompt for spec generation eval |
| `Test/e2e/EeTests/TestCoverageAttribute.cs` | `[TestCoverage]` attribute |
| `Test/e2e/E2eTests.Analyzers/RequireTestCoverageAttributeAnalyzer.cs` | E2E008 analyzer |
| `Task/Runner/Nuke/Build.Test.cs` | 4 eval Nuke targets |
| `Task/Runner/Nuke/Build.Lint.cs` | `LintSpecVerify` target |
| `Task/Runner/Nuke/Build.Paths.cs` | Eval report paths |

## Test plan
- [x] `BuildServer` — 0 warnings, 0 errors
- [x] `LintNukeVerify` — 5/5 tests pass
- [x] `LintSpecVerify` — all checks pass
- [x] `TestEvalsMasterList` — 81 entries extracted
- [x] `TestEvalsCoverage` — 98.7/100 (79 covered, 2 weak, 0 missing)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)