### PR TITLE
fix: allow standalone docker commands in enforce-nuke hook

### DIFF
--- a/.claude/hooks/enforce-nuke.sh
+++ b/.claude/hooks/enforce-nuke.sh
@@ -7,8 +7,8 @@ if echo "$COMMAND" | grep -qE '(^|\||&&|;)\s*dotnet\b'; then
   exit 2
 fi
 
-if echo "$COMMAND" | grep -qE '(^|\||&&|;)\s*docker(-compose)?\b' || echo "$COMMAND" | grep -qE '(^|\||&&|;)\s*docker\s+compose\b'; then
-  echo "BLOCKED: Do not run docker/docker-compose commands directly. Use ./build.sh <target> instead. Key targets: RunLocalPublish, RunLocalDependencies, RunLocalDependenciesDown, DbReset, TestServerPostman*, TestE2e" >&2
+if echo "$COMMAND" | grep -qE '(^|\||&&|;)\s*docker-compose\b' || echo "$COMMAND" | grep -qE '(^|\||&&|;)\s*docker\s+compose\b'; then
+  echo "BLOCKED: Do not run docker compose commands directly. Use ./build.sh <target> instead. Key targets: RunLocalPublish, RunLocalDependencies, RunLocalDependenciesDown, DbReset, TestServerPostman*, TestE2e" >&2
   exit 2
 fi
 


### PR DESCRIPTION
## Summary
- The enforce-nuke hook was blocking all `docker` commands including inspection commands like `docker ps`
- Now only blocks `docker compose` and `docker-compose`, allowing standalone docker commands through

## Test plan
- [x] Verified `docker ps` is no longer blocked
- [x] `docker compose` commands still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)