### PR TITLE
feat: add OpenTelemetry + local Grafana observability stack

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -60,6 +60,7 @@
         "RunLocalDocsMcpServerUp",
         "RunLocalHotReload",
         "RunLocalPublish",
+        "RunLocalPublishDown",
         "TestClient",
         "TestE2e",
         "TestE2eArticles",

--- a/App/Server/Directory.Packages.props
+++ b/App/Server/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="Ardalis.Specification" Version="9.2.0" />
     <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="9.2.0" />
     <PackageVersion Include="Audit.EntityFramework.Core" Version="31.3.1" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.6.0" />
     <PackageVersion Include="Audit.EntityFramework.Identity.Core" Version="31.3.1" />
     <PackageVersion Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageVersion Include="Finbuckle.MultiTenant" Version="10.0.1" />
@@ -56,6 +57,13 @@
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.1-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.15.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
     <PackageVersion Include="ReportGenerator" Version="5.4.8" />
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />

--- a/App/Server/src/Server.SharedKernel/MediatR/TracingBehavior.cs
+++ b/App/Server/src/Server.SharedKernel/MediatR/TracingBehavior.cs
@@ -1,0 +1,44 @@
+﻿using System.Diagnostics;
+using MediatR;
+using Server.SharedKernel.Result;
+
+namespace Server.SharedKernel.MediatR;
+
+/// <summary>
+/// MediatR pipeline behavior that creates OpenTelemetry spans for all requests.
+/// Uses System.Diagnostics.ActivitySource (no OTel SDK dependency in SharedKernel).
+/// </summary>
+/// <typeparam name="TRequest">The request type implementing IResultRequest{T}</typeparam>
+/// <typeparam name="T">The inner value type of Result{T}</typeparam>
+public class TracingBehavior<TRequest, T> : IPipelineBehavior<TRequest, Result<T>>
+  where TRequest : IResultRequest<T>
+{
+  private static readonly ActivitySource ActivitySource = new("Conduit.MediatR");
+
+  public async Task<Result<T>> Handle(TRequest request, RequestHandlerDelegate<Result<T>> next, CancellationToken cancellationToken)
+  {
+    var requestName = typeof(TRequest).Name;
+    var kind = request is ICommand<T> ? "Command" : "Query";
+
+    using var activity = ActivitySource.StartActivity($"MediatR {kind}: {requestName}", ActivityKind.Internal);
+
+    if (activity is null)
+    {
+      return await next(cancellationToken);
+    }
+
+    activity.SetTag("mediatr.request.name", requestName);
+    activity.SetTag("mediatr.request.kind", kind);
+
+    var result = await next(cancellationToken);
+
+    activity.SetTag("mediatr.result.status", result.Status.ToString());
+
+    if (!result.IsSuccess)
+    {
+      activity.SetStatus(ActivityStatusCode.Error, result.Status.ToString());
+    }
+
+    return result;
+  }
+}

--- a/App/Server/src/Server.Web/Configurations/MediatrConfigs.cs
+++ b/App/Server/src/Server.Web/Configurations/MediatrConfigs.cs
@@ -55,9 +55,11 @@ public static class MediatrConfigs
       var resultType = typeof(Result<>).MakeGenericType(innerType);
 
       // Register behaviors in the correct order:
-      // 1. LoggingBehavior (logs request handling)
-      // 2. TransactionBehavior (wraps handler execution in transaction)
-      // 3. ExceptionHandlingBehavior (catches exceptions and converts to Result)
+      // 1. TracingBehavior (creates OpenTelemetry spans)
+      // 2. LoggingBehavior (logs request handling)
+      // 3. TransactionBehavior (wraps handler execution in transaction)
+      // 4. ExceptionHandlingBehavior (catches exceptions and converts to Result)
+      RegisterBehavior(services, typeof(TracingBehavior<,>), requestType, innerType, resultType);
       RegisterBehavior(services, typeof(LoggingBehavior<,>), requestType, innerType, resultType);
       RegisterBehavior(services, typeof(TransactionBehavior<,>), requestType, innerType, resultType);
       RegisterBehavior(services, typeof(ExceptionHandlingBehavior<,>), requestType, innerType, resultType);

--- a/App/Server/src/Server.Web/Configurations/MiddlewareConfig.cs
+++ b/App/Server/src/Server.Web/Configurations/MiddlewareConfig.cs
@@ -88,6 +88,8 @@ public static class MiddlewareConfig
       Predicate = check => check.Tags.Contains("ready"), // Only run readiness checks (database)
     });
 
+    app.MapPrometheusScrapingEndpoint();
+
     await RunMigrationsAsync(app);
 
     return app;

--- a/App/Server/src/Server.Web/Configurations/OpenTelemetryConfigs.cs
+++ b/App/Server/src/Server.Web/Configurations/OpenTelemetryConfigs.cs
@@ -1,0 +1,74 @@
+﻿using Azure.Monitor.OpenTelemetry.Exporter;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace Server.Web.Configurations;
+
+public static class OpenTelemetryConfigs
+{
+  private const string ServiceName = "Conduit";
+
+  public static IServiceCollection AddOpenTelemetryConfigs(
+    this IServiceCollection services,
+    IConfiguration configuration,
+    IWebHostEnvironment environment)
+  {
+    var otlpEndpoint = configuration["OpenTelemetry:OtlpEndpoint"];
+    var appInsightsConnectionString = configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]
+      ?? Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING");
+
+    var resourceBuilder = ResourceBuilder.CreateDefault()
+      .AddService(ServiceName, serviceVersion: typeof(Program).Assembly.GetName().Version?.ToString() ?? "1.0.0");
+
+    services.AddOpenTelemetry()
+      .WithTracing(tracing =>
+      {
+        tracing.SetResourceBuilder(resourceBuilder)
+          .AddAspNetCoreInstrumentation(options =>
+          {
+            options.Filter = context =>
+              !context.Request.Path.StartsWithSegments("/health") &&
+              !context.Request.Path.StartsWithSegments("/swagger") &&
+              !context.Request.Path.StartsWithSegments("/metrics");
+          })
+          .AddHttpClientInstrumentation()
+          .AddEntityFrameworkCoreInstrumentation()
+          .AddSource("Conduit.MediatR");
+
+        if (!string.IsNullOrEmpty(otlpEndpoint))
+        {
+          tracing.AddOtlpExporter(options =>
+          {
+            options.Endpoint = new Uri(otlpEndpoint);
+          });
+        }
+
+        if (!string.IsNullOrEmpty(appInsightsConnectionString))
+        {
+          tracing.AddAzureMonitorTraceExporter(options =>
+          {
+            options.ConnectionString = appInsightsConnectionString;
+          });
+        }
+      })
+      .WithMetrics(metrics =>
+      {
+        metrics.SetResourceBuilder(resourceBuilder)
+          .AddAspNetCoreInstrumentation()
+          .AddHttpClientInstrumentation()
+          .AddRuntimeInstrumentation()
+          .AddPrometheusExporter();
+
+        if (!string.IsNullOrEmpty(appInsightsConnectionString))
+        {
+          metrics.AddAzureMonitorMetricExporter(options =>
+          {
+            options.ConnectionString = appInsightsConnectionString;
+          });
+        }
+      });
+
+    return services;
+  }
+}

--- a/App/Server/src/Server.Web/Program.cs
+++ b/App/Server/src/Server.Web/Program.cs
@@ -21,7 +21,7 @@ var appLogger = new SerilogLoggerFactory(logger)
 
 builder.Services.AddOptionConfigs(builder.Configuration, appLogger, builder);
 builder.Services.AddServiceConfigs(appLogger, builder);
-
+builder.Services.AddOpenTelemetryConfigs(builder.Configuration, builder.Environment);
 
 builder.Services.AddFastEndpoints(o =>
                 {
@@ -74,6 +74,7 @@ app.MapWhen(
   context =>
     !context.Request.Path.StartsWithSegments("/api") &&
     !context.Request.Path.StartsWithSegments("/health") &&
+    !context.Request.Path.StartsWithSegments("/metrics") &&
     !context.Request.Path.StartsWithSegments($"/{DevOnly.ROUTE}"),
   builder => builder.Run(async context =>
   {

--- a/App/Server/src/Server.Web/Server.Web.csproj
+++ b/App/Server/src/Server.Web/Server.Web.csproj
@@ -30,6 +30,14 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Serilog.AspNetCore" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/App/Server/src/Server.Web/appsettings.Testing.json
+++ b/App/Server/src/Server.Web/appsettings.Testing.json
@@ -47,5 +47,8 @@
   },
   "FeatureManagement": {
     "SampleFeature": true
+  },
+  "OpenTelemetry": {
+    "OtlpEndpoint": ""
   }
 }

--- a/App/Server/src/Server.Web/appsettings.json
+++ b/App/Server/src/Server.Web/appsettings.json
@@ -73,7 +73,7 @@
       {
         "Name": "Console",
         "Args": {
-          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {CorrelationId} {SourceContext} {Message:lj}{NewLine}{Exception}"
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {TraceId} {CorrelationId} {SourceContext} {Message:lj}{NewLine}{Exception}"
         }
       },
       {
@@ -107,6 +107,9 @@
   "I18n": {
     "DefaultLanguage": "en",
     "SupportedLanguages": ["en", "ja"]
+  },
+  "OpenTelemetry": {
+    "OtlpEndpoint": "http://localhost:4317"
   },
   "Mailserver": {
     "Server": "localhost",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ These are the primary rules.
 Reference as needed:
 - `SPEC-REFERENCE.md` — complete API spec (the source of truth for what to build)
 - `Docs/architecture.md` — tech stack, folder structure, build commands
+- `Docs/observability.md` — OpenTelemetry tracing/metrics, Grafana/Jaeger/Prometheus stack
 
 ## Rules Index
 

--- a/Docs/observability.md
+++ b/Docs/observability.md
@@ -1,0 +1,187 @@
+# Observability Stack
+
+## Overview
+
+The application uses OpenTelemetry for distributed tracing and metrics, with Serilog for structured logging. In local development, telemetry flows to a Grafana + Jaeger + Prometheus stack. In production, the same instrumentation exports to Azure Application Insights via environment variable — zero code changes.
+
+```
+LOCAL DEV:
+.NET App
+├── Traces  → OTLP gRPC push  → Jaeger      → Grafana / Jaeger UI
+├── Metrics → /metrics scrape  → Prometheus  → Grafana
+└── Logs    → Serilog          → Seq (unchanged)
+
+PRODUCTION (Azure):
+.NET App
+├── Traces  ─┐
+├── Metrics  ├→ Azure Monitor Exporter → Application Insights
+└── Logs     ─┘   (via APPLICATIONINSIGHTS_CONNECTION_STRING env var)
+```
+
+## Local URLs
+
+| Service | URL | Purpose |
+|:--------|:----|:--------|
+| **Grafana** | [http://localhost:3000](http://localhost:3000) | Dashboards, trace explorer, metrics explorer |
+| **Jaeger UI** | [http://localhost:16686](http://localhost:16686) | Native trace search and visualization |
+| **Seq** | [http://localhost:5341](http://localhost:5341) | Structured log search (Serilog) |
+| **Prometheus** | [http://localhost:9090](http://localhost:9090) | Metrics query UI, target health |
+| **App Metrics** | [http://localhost:5000/metrics](http://localhost:5000/metrics) | Prometheus scrape endpoint exposed by the app |
+
+## Audit Logs (Audit.NET)
+
+Audit.NET captures entity-level change tracking for all EF Core operations, writing JSON audit logs to disk:
+
+- **Location**: `Logs/Server.Web/Audit.NET/` (configurable via `Audit:LogsPath` in appsettings)
+- **What's captured**: Insert, Update, Delete operations with before/after values for every entity property
+- **Format**: JSON files with timestamps, entity type, primary key, changed properties, old/new values
+- **Identity events**: Authentication events (login, logout, failed attempts) are also audited
+
+See `Docs/AUDIT.md` for full details on the audit log format and configuration.
+
+## What Gets Instrumented
+
+### Traces (Jaeger → Grafana)
+
+- **ASP.NET Core** — every HTTP request (excluding `/health`, `/swagger`, `/metrics`)
+- **HttpClient** — outgoing HTTP calls
+- **Entity Framework Core** — database queries and commands
+- **MediatR** — every command and query via `TracingBehavior`
+  - Span name: `MediatR Command: CreateArticleCommand` or `MediatR Query: GetProfileQuery`
+  - Tags: `mediatr.request.name`, `mediatr.request.kind` (Command/Query), `mediatr.result.status`
+  - Error status set on non-success results
+
+### Metrics (Prometheus → Grafana)
+
+- **ASP.NET Core** — `http.server.request.duration`, request counts by status code, route
+- **HttpClient** — outgoing request duration and counts
+- **.NET Runtime** — GC collections, heap size, threadpool queue length, exception count
+- **SQL Server** — connections, batch requests/sec, page life expectancy, buffer cache hit ratio, deadlocks (via `sql-exporter` container)
+
+### Logs (Serilog → Seq)
+
+- Structured logging with `TraceId` enrichment for cross-correlation
+- Console output includes `{TraceId}` so you can search Grafana traces by the ID shown in terminal
+- Seq shows `TraceId` as a searchable property on every log event
+
+## Cross-Correlation
+
+Serilog 4.x automatically enriches log events with `TraceId` and `SpanId` from `Activity.Current` via the `FromLogContext` enricher. This means:
+
+1. See a log entry in Seq with a `TraceId`
+2. Copy that `TraceId` into Jaeger UI or Grafana → Explore → Jaeger
+3. See the full distributed trace with ASP.NET Core, EF Core, and MediatR spans
+
+## Architecture
+
+### TracingBehavior
+
+`App/Server/src/Server.SharedKernel/MediatR/TracingBehavior.cs`
+
+A MediatR pipeline behavior that wraps every command/query in an OpenTelemetry span. Uses only `System.Diagnostics.ActivitySource` — no OTel SDK dependency in SharedKernel. Registered as the first pipeline behavior:
+
+```
+TracingBehavior → LoggingBehavior → TransactionBehavior → ExceptionHandlingBehavior
+```
+
+### OpenTelemetryConfigs
+
+`App/Server/src/Server.Web/Configurations/OpenTelemetryConfigs.cs`
+
+Extension method that configures:
+- **Tracing**: ASP.NET Core + HttpClient + EF Core + MediatR instrumentation, OTLP exporter
+- **Metrics**: ASP.NET Core + HttpClient + Runtime instrumentation, Prometheus exporter
+- **Azure Monitor**: Conditionally added when `APPLICATIONINSIGHTS_CONNECTION_STRING` env var is set
+
+### Docker Compose Services
+
+Defined in `Task/LocalDev/docker-compose.dev-deps.yml`:
+
+| Container | Image | Purpose |
+|:----------|:------|:--------|
+| `jaeger` | `jaegertracing/all-in-one` | Trace storage + UI, receives OTLP gRPC on port 4317 |
+| `prometheus` | `prom/prometheus` | Metrics storage, scrapes app `/metrics` and SQL exporter |
+| `sql-exporter` | `awaragi/prometheus-mssql-exporter` | Exports SQL Server DMV metrics to Prometheus |
+| `grafana` | `grafana/grafana` | Visualization — auto-provisioned with Jaeger + Prometheus datasources |
+
+Config files in `Task/LocalDev/config/`:
+- `prometheus.yml` — scrape targets (host app, Docker app, SQL Server)
+- `grafana/datasources.yaml` — auto-provisioned datasources
+
+## Configuration
+
+### Local Development (`appsettings.json`)
+
+```json
+{
+  "OpenTelemetry": {
+    "OtlpEndpoint": "http://localhost:4317"
+  }
+}
+```
+
+### Testing (`appsettings.Testing.json`)
+
+```json
+{
+  "OpenTelemetry": {
+    "OtlpEndpoint": ""
+  }
+}
+```
+
+Empty endpoint disables OTLP export — traces and metrics are still collected in-process but not exported.
+
+### Docker (`docker-compose.publish.yml`)
+
+```yaml
+OpenTelemetry__OtlpEndpoint: "http://jaeger:4317"
+```
+
+### Production (Azure Application Insights)
+
+Set the `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable. The code auto-detects it and adds Azure Monitor trace and metric exporters. OTLP and Prometheus exporters still work alongside if configured.
+
+## Using Grafana
+
+### Conduit Overview Dashboard
+
+A pre-provisioned dashboard is available at [http://localhost:3000/d/conduit-overview](http://localhost:3000/d/conduit-overview) with:
+- Recent traces table (click any trace to see the full span waterfall)
+- HTTP request rate and latency percentiles (p50/p95/p99)
+- Requests by status code
+- .NET runtime metrics (GC collections, heap size, thread pool)
+- SQL Server metrics (connections, batch requests/sec, page life expectancy)
+
+### Viewing Traces
+
+**Via Jaeger UI** (recommended for trace exploration):
+1. Open [http://localhost:16686](http://localhost:16686)
+2. Select service `Conduit` from the dropdown
+3. Click **Find Traces** to see recent traces
+4. Click a trace to see the span waterfall (ASP.NET Core → MediatR → EF Core)
+
+**Via Grafana**:
+1. Open [http://localhost:3000](http://localhost:3000)
+2. Go to **Explore** (compass icon in sidebar)
+3. Select **Jaeger** datasource
+4. Search by service name `Conduit`
+
+### Viewing Metrics
+
+1. Open [http://localhost:3000](http://localhost:3000)
+2. Go to **Explore** (compass icon in sidebar)
+3. Select **Prometheus** datasource
+4. Query metrics like:
+   - `http_server_request_duration_seconds_bucket` — request latency histogram
+   - `process_runtime_dotnet_gc_collections_total` — GC collection counts
+   - `mssql_connections` — SQL Server connection count
+
+### SQL Server Metrics
+
+The `sql-exporter` container exposes SQL Server DMV metrics including:
+- Active connections
+- Batch requests per second
+- Page life expectancy
+- Buffer cache hit ratio
+- Deadlock count

--- a/Task/LocalDev/config/grafana/dashboards.yaml
+++ b/Task/LocalDev/config/grafana/dashboards.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards/json
+      foldersFromFilesStructure: false

--- a/Task/LocalDev/config/grafana/dashboards/conduit-overview.json
+++ b/Task/LocalDev/config/grafana/dashboards/conduit-overview.json
@@ -1,0 +1,217 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "title": "Recent Traces",
+      "type": "table",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "jaeger", "uid": "jaeger" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "jaeger", "uid": "jaeger" },
+          "queryType": "search",
+          "service": "Conduit",
+          "limit": 20
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      }
+    },
+    {
+      "title": "HTTP Request Rate (req/s)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(http_server_request_duration_seconds_count[1m]))",
+          "legendFormat": "Total req/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "HTTP Request Duration (p50 / p95 / p99)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.50, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95"
+        },
+        {
+          "refId": "C",
+          "expr": "histogram_quantile(0.99, sum(rate(http_server_request_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "HTTP Requests by Status Code",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(http_server_request_duration_seconds_count[1m])) by (http_response_status_code)",
+          "legendFormat": "{{http_response_status_code}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "GC Collections",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 18 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(process_runtime_dotnet_gc_collections_total[5m])) by (generation)",
+          "legendFormat": "Gen {{generation}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "GC Heap Size",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 26 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "process_runtime_dotnet_gc_heap_size_bytes",
+          "legendFormat": "Heap Size"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "Thread Pool Queue Length",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 26 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "process_runtime_dotnet_thread_pool_queue_length",
+          "legendFormat": "Queue Length"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "SQL Server — Active Connections",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 34 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "mssql_connections",
+          "legendFormat": "Connections"
+        }
+      ]
+    },
+    {
+      "title": "SQL Server — Batch Requests/sec",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 9, "x": 6, "y": 34 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(mssql_batch_requests[1m])",
+          "legendFormat": "Batch req/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "SQL Server — Page Life Expectancy",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 9, "x": 15, "y": 34 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "mssql_page_life_expectancy",
+          "legendFormat": "PLE (seconds)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      }
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": ["conduit", "opentelemetry"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "title": "Conduit — Overview",
+  "uid": "conduit-overview"
+}

--- a/Task/LocalDev/config/grafana/datasources.yaml
+++ b/Task/LocalDev/config/grafana/datasources.yaml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+datasources:
+  - name: Jaeger
+    type: jaeger
+    uid: jaeger
+    access: proxy
+    url: http://jaeger:16686
+    isDefault: true
+
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090

--- a/Task/LocalDev/config/prometheus.yml
+++ b/Task/LocalDev/config/prometheus.yml
@@ -1,0 +1,20 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: conduit-server
+    # When app runs on host (normal dev via dotnet run)
+    static_configs:
+      - targets: ["host.docker.internal:5000"]
+
+  - job_name: conduit-server-docker
+    # When app runs in Docker (RunLocalPublish)
+    scheme: https
+    tls_config:
+      insecure_skip_verify: true
+    static_configs:
+      - targets: ["api:5001"]
+
+  - job_name: sqlserver
+    static_configs:
+      - targets: ["sql-exporter:4000"]

--- a/Task/LocalDev/docker-compose.dev-deps.yml
+++ b/Task/LocalDev/docker-compose.dev-deps.yml
@@ -49,9 +49,66 @@ services:
     networks:
       - app-network
 
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    ports:
+      - "4317:4317"
+      - "16686:16686"
+    networks:
+      - app-network
+
+  prometheus:
+    image: prom/prometheus:latest
+    command: ["--config.file=/etc/prometheus/prometheus.yml", "--web.enable-remote-write-receiver"]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ./config/prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus-data:/prometheus
+    ports:
+      - "9090:9090"
+    networks:
+      - app-network
+
+  sql-exporter:
+    image: awaragi/prometheus-mssql-exporter:latest
+    environment:
+      SERVER: sqlserver
+      PORT: 1433
+      USERNAME: sa
+      PASSWORD: "YourStrong@Passw0rd"
+    depends_on:
+      sqlserver:
+        condition: service_healthy
+    networks:
+      - app-network
+
+  grafana:
+    image: grafana/grafana:latest
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+    volumes:
+      - ./config/grafana/datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+      - ./config/grafana/dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml
+      - ./config/grafana/dashboards:/etc/grafana/provisioning/dashboards/json
+      - grafana-data:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - jaeger
+      - prometheus
+    networks:
+      - app-network
+
 volumes:
   seq-data:
   sqlserver-data:
+  prometheus-data:
+  grafana-data:
 
 networks:
   app-network:

--- a/Task/LocalDev/docker-compose.publish.yml
+++ b/Task/LocalDev/docker-compose.publish.yml
@@ -13,6 +13,7 @@ services:
       Audit__LogsPath: /app/Logs/RunLocalPublish/Server.Web/Audit.NET
       Serilog__WriteTo__1__Args__Path: /app/Logs/RunLocalPublish/Server.Web/Serilog/logs.json
       Serilog__WriteTo__2__Args__ServerUrl: http://seq:80
+      OpenTelemetry__OtlpEndpoint: "http://jaeger:4317"
     ports:
       - "5000:5000"
       - "5001:5001"

--- a/Task/Runner/Nuke/Build.RunLocal.cs
+++ b/Task/Runner/Nuke/Build.RunLocal.cs
@@ -17,6 +17,8 @@ public partial class Build
 
   internal AbsolutePath NgrokPidFile => PidDirectory / "ngrok.pid";
 
+  internal AbsolutePath DockerComposePublish => TaskLocalDevDirectory / "docker-compose.publish.yml";
+
   internal Target RunLocalHotReload => _ => _
     .Description("Run backend locally using Docker Compose with SQL Server and hot-reload")
     .DependsOn(PathsCleanDirectories)
@@ -52,21 +54,27 @@ public partial class Build
     {
       Log.Information("Starting local development environment with Docker Compose (published artifact)...");
 
-      var publishComposeFile = TaskLocalDevDirectory / "docker-compose.publish.yml";
-
       var envVars = new Dictionary<string, string>
       {
         ["DOCKER_BUILDKIT"] = "1",
       };
 
       Log.Information("Running Docker Compose for local development with published artifact...");
-      var args = $"compose -f {publishComposeFile} -p {Constants.Docker.Projects.App} up --build";
+      var args = $"compose -f {DockerComposePublish} -p {Constants.Docker.Projects.App} up --build";
       var process = ProcessTasks.StartProcess(
             "docker",
             args,
             workingDirectory: RootDirectory,
             environmentVariables: envVars);
       process.WaitForExit();
+    });
+
+  internal Target RunLocalPublishDown => _ => _
+    .Description("Stop backend Docker Compose containers")
+    .Executes(() =>
+    {
+      Log.Information("Stopping local published app containers...");
+      DockerTasks.Docker($"compose -f {DockerComposePublish} -p {Constants.Docker.Projects.App} down", workingDirectory: RootDirectory);
     });
 
   internal Target RunLocalDependencies => _ => _


### PR DESCRIPTION
## Summary
- Ports the OpenTelemetry observability stack from `multi-tenant-starter-template` to `main`
- Adds distributed tracing via Jaeger (OTLP gRPC), metrics via Prometheus + Grafana, and SQL Server metrics via sql-exporter
- Adds MediatR `TracingBehavior` as first pipeline behavior creating OpenTelemetry spans for all commands/queries
- Adds `OpenTelemetryConfigs.cs` with conditional Azure Monitor export (auto-enabled via `APPLICATIONINSIGHTS_CONNECTION_STRING` env var)
- Adds Prometheus `/metrics` scrape endpoint and `{TraceId}` to Serilog console output for cross-correlation
- Adds pre-provisioned Grafana dashboard (Conduit Overview) with HTTP metrics, .NET runtime, and SQL Server panels
- Adds `RunLocalPublishDown` Nuke target for container teardown

## Files Changed
**New files (7):**
- `App/Server/src/Server.SharedKernel/MediatR/TracingBehavior.cs`
- `App/Server/src/Server.Web/Configurations/OpenTelemetryConfigs.cs`
- `Task/LocalDev/config/prometheus.yml`
- `Task/LocalDev/config/grafana/datasources.yaml`
- `Task/LocalDev/config/grafana/dashboards.yaml`
- `Task/LocalDev/config/grafana/dashboards/conduit-overview.json`
- `Docs/observability.md`

**Modified files (12):**
- NuGet packages (8 OTel packages), Program.cs, MediatrConfigs.cs, MiddlewareConfig.cs, appsettings, docker-compose files, Nuke build targets

## Test plan
- [x] `LintAllVerify` — all checks pass
- [x] `BuildServer` — compiles with 0 warnings, 0 errors
- [x] `TestServer` — all backend tests pass (OTel disabled in test config)
- [x] `TestE2e` — all E2E tests pass (no SPA fallback regression for `/metrics`)
- [x] Docker Compose starts all observability containers (jaeger, prometheus, grafana, sql-exporter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)