### PR TITLE
chore: increase E2E flake detection matrix from 10x to 15x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -644,7 +644,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1


### PR DESCRIPTION
## Summary
- Increases the E2E flake detection matrix from 10 parallel runs to 15 for better flake coverage

## Test plan
- [ ] CI passes with the expanded matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)