### PR TITLE
docs: add backend architecture diagram

### DIFF
--- a/Docs/architecture-diagram.html
+++ b/Docs/architecture-diagram.html
@@ -1,0 +1,555 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Backend Architecture</title>
+<style>
+  :root {
+    --web: #4589ff;
+    --web-bg: #edf5ff;
+    --mediator: #a56eff;
+    --mediator-bg: #f6f2ff;
+    --usecases: #0e6027;
+    --usecases-bg: #defbe6;
+    --core: #b28600;
+    --core-bg: #fff8e1;
+    --shared: #6c757d;
+    --shared-bg: #f4f4f4;
+    --infra: #d02670;
+    --infra-bg: #fff0f7;
+    --external: #343a3f;
+    --external-bg: #e8e8e8;
+    --arrow: #525252;
+    --bg: #ffffff;
+    --text: #161616;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    padding: 32px;
+    line-height: 1.5;
+  }
+
+  h1 {
+    font-size: 28px;
+    font-weight: 600;
+    margin-bottom: 8px;
+  }
+
+  .subtitle {
+    color: #525252;
+    font-size: 14px;
+    margin-bottom: 32px;
+  }
+
+  .diagram {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    max-width: 1100px;
+    margin: 0 auto;
+    position: relative;
+  }
+
+  /* Layer rows */
+  .layer {
+    border: 2px solid;
+    border-radius: 8px;
+    padding: 16px 20px;
+    position: relative;
+    margin-bottom: 16px;
+  }
+
+  .layer-label {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+    position: absolute;
+    top: -10px;
+    left: 16px;
+    padding: 0 8px;
+  }
+
+  .layer-boxes {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-top: 4px;
+  }
+
+  .box {
+    background: white;
+    border: 1.5px solid;
+    border-radius: 6px;
+    padding: 10px 14px;
+    flex: 1;
+    min-width: 180px;
+  }
+
+  .box-title {
+    font-size: 13px;
+    font-weight: 600;
+    margin-bottom: 4px;
+  }
+
+  .box-code {
+    font-family: 'IBM Plex Mono', 'Fira Code', monospace;
+    font-size: 11px;
+    color: #525252;
+    margin-bottom: 2px;
+  }
+
+  .box-desc {
+    font-size: 11px;
+    color: #6f6f6f;
+    font-style: italic;
+  }
+
+  /* Arrow between layers */
+  .arrow-down {
+    text-align: center;
+    font-size: 22px;
+    color: var(--arrow);
+    margin: -8px 0;
+    z-index: 1;
+    position: relative;
+  }
+
+  .arrow-label {
+    font-size: 10px;
+    color: #6f6f6f;
+    font-family: 'IBM Plex Mono', monospace;
+    vertical-align: middle;
+    margin-left: 8px;
+  }
+
+  /* Layer colors */
+  .layer-client { border-color: #8d8d8d; background: #f9f9f9; }
+  .layer-client .layer-label { background: #f9f9f9; color: #525252; }
+
+  .layer-web { border-color: var(--web); background: var(--web-bg); }
+  .layer-web .layer-label { background: var(--web-bg); color: var(--web); }
+  .layer-web .box { border-color: var(--web); }
+  .layer-web .box-title { color: var(--web); }
+
+  .layer-mediator { border-color: var(--mediator); background: var(--mediator-bg); }
+  .layer-mediator .layer-label { background: var(--mediator-bg); color: var(--mediator); }
+  .layer-mediator .box { border-color: var(--mediator); }
+  .layer-mediator .box-title { color: var(--mediator); }
+
+  .layer-usecases { border-color: var(--usecases); background: var(--usecases-bg); }
+  .layer-usecases .layer-label { background: var(--usecases-bg); color: var(--usecases); }
+  .layer-usecases .box { border-color: var(--usecases); }
+  .layer-usecases .box-title { color: var(--usecases); }
+
+  .layer-core { border-color: var(--core); background: var(--core-bg); }
+  .layer-core .layer-label { background: var(--core-bg); color: var(--core); }
+  .layer-core .box { border-color: var(--core); }
+  .layer-core .box-title { color: var(--core); }
+
+  .layer-shared { border-color: var(--shared); background: var(--shared-bg); }
+  .layer-shared .layer-label { background: var(--shared-bg); color: var(--shared); }
+  .layer-shared .box { border-color: var(--shared); }
+  .layer-shared .box-title { color: var(--shared); }
+
+  .layer-infra { border-color: var(--infra); background: var(--infra-bg); }
+  .layer-infra .layer-label { background: var(--infra-bg); color: var(--infra); }
+  .layer-infra .box { border-color: var(--infra); }
+  .layer-infra .box-title { color: var(--infra); }
+
+  .layer-external { border-color: var(--external); background: var(--external-bg); }
+  .layer-external .layer-label { background: var(--external-bg); color: var(--external); }
+  .layer-external .box { border-color: var(--external); }
+  .layer-external .box-title { color: var(--external); }
+
+  /* Dependency rule sidebar */
+  .dep-rule {
+    position: fixed;
+    right: 32px;
+    top: 50%;
+    transform: translateY(-50%);
+    writing-mode: vertical-lr;
+    text-orientation: mixed;
+    font-size: 11px;
+    color: #a8a8a8;
+    letter-spacing: 2px;
+    font-weight: 600;
+    text-transform: uppercase;
+  }
+
+  .dep-rule::before {
+    content: '';
+    display: block;
+    width: 1.5px;
+    height: 80px;
+    background: #c6c6c6;
+    margin: 0 auto 8px;
+  }
+
+  .dep-rule::after {
+    content: '';
+    display: block;
+    width: 1.5px;
+    height: 80px;
+    background: #c6c6c6;
+    margin: 8px auto 0;
+  }
+
+  /* Legend */
+  .legend {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin-top: 24px;
+    padding-top: 16px;
+    border-top: 1px solid #e0e0e0;
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+  }
+
+  .legend-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 3px;
+    border: 1.5px solid;
+  }
+
+  /* Result mapping table */
+  .result-table {
+    margin-top: 32px;
+    border-collapse: collapse;
+    font-size: 13px;
+    width: 100%;
+    max-width: 700px;
+  }
+
+  .result-table th {
+    text-align: left;
+    padding: 8px 12px;
+    border-bottom: 2px solid #e0e0e0;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: #525252;
+  }
+
+  .result-table td {
+    padding: 6px 12px;
+    border-bottom: 1px solid #f0f0f0;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 12px;
+  }
+
+  .result-table tr:hover { background: #f9f9f9; }
+
+  .http-2xx { color: #198038; font-weight: 600; }
+  .http-4xx { color: #da1e28; font-weight: 600; }
+  .http-5xx { color: #6929c4; font-weight: 600; }
+
+  .note {
+    margin-top: 24px;
+    padding: 12px 16px;
+    background: #f4f4f4;
+    border-left: 3px solid #8d8d8d;
+    font-size: 12px;
+    color: #525252;
+  }
+
+  @media (max-width: 768px) {
+    body { padding: 16px; }
+    .box { min-width: 140px; }
+    .dep-rule { display: none; }
+  }
+</style>
+</head>
+<body>
+
+<h1>Backend Architecture</h1>
+<p class="subtitle">Ardalis Clean Architecture &middot; .NET 10 &middot; FastEndpoints &middot; MediatR CQRS &middot; EF Core</p>
+
+<div class="diagram">
+
+  <!-- Client -->
+  <div class="layer layer-client">
+    <span class="layer-label">Client</span>
+    <div class="layer-boxes">
+      <div class="box">
+        <div class="box-title">HTTP Request</div>
+        <div class="box-code">POST /api/articles</div>
+        <div class="box-desc">Bearer token or cookie authentication</div>
+      </div>
+      <div class="box">
+        <div class="box-title">HTTP Response</div>
+        <div class="box-code">200 / 201 / 400 / 404 / 422</div>
+        <div class="box-desc">JSON body with ProblemDetails on error</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="arrow-down">&darr; &uarr;<span class="arrow-label">JSON over HTTPS</span></div>
+
+  <!-- Web Layer -->
+  <div class="layer layer-web">
+    <span class="layer-label">Server.Web &mdash; Presentation</span>
+    <div class="layer-boxes">
+      <div class="box">
+        <div class="box-title">ASP.NET Middleware</div>
+        <div class="box-code">UseExceptionHandler &rarr; UseMultiTenant<br>&rarr; UseAuth &rarr; UseAuthorization</div>
+        <div class="box-desc">Finbuckle tenant resolution from __tenant__ claim</div>
+      </div>
+      <div class="box">
+        <div class="box-title">FastEndpoints</div>
+        <div class="box-code">Endpoint&lt;TReq, TRes, TMapper&gt;</div>
+        <div class="box-desc">Route matching, model binding, authorization</div>
+      </div>
+      <div class="box">
+        <div class="box-title">FluentValidation</div>
+        <div class="box-code">Validator&lt;TRequest&gt;</div>
+        <div class="box-desc">Auto-discovered; returns 400 on failure</div>
+      </div>
+      <div class="box">
+        <div class="box-title">Response Mapping</div>
+        <div class="box-code">Send.ResultMapperAsync()</div>
+        <div class="box-desc">Result&lt;T&gt; &rarr; HTTP status + ResponseMapper</div>
+      </div>
+      <div class="box">
+        <div class="box-title">GlobalExceptionHandler</div>
+        <div class="box-code">IGlobalPostProcessor</div>
+        <div class="box-desc">Last-resort exception &rarr; ProblemDetails</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="arrow-down">&darr; &uarr;<span class="arrow-label">IMediator.Send(command/query)</span></div>
+
+  <!-- MediatR Pipeline -->
+  <div class="layer layer-mediator">
+    <span class="layer-label">MediatR Pipeline &mdash; Behaviors (ordered)</span>
+    <div class="layer-boxes">
+      <div class="box">
+        <div class="box-title">1. TracingBehavior</div>
+        <div class="box-code">ActivitySource: App.MediatR</div>
+        <div class="box-desc">OpenTelemetry span per request</div>
+      </div>
+      <div class="box">
+        <div class="box-title">2. LoggingBehavior</div>
+        <div class="box-code">Serilog {@Request}, elapsed ms</div>
+        <div class="box-desc">Structured logging with Stopwatch</div>
+      </div>
+      <div class="box">
+        <div class="box-title">3. TransactionBehavior</div>
+        <div class="box-code">IUnitOfWork (ICommand only)</div>
+        <div class="box-desc">EF transaction; commit on success, rollback on failure</div>
+      </div>
+      <div class="box">
+        <div class="box-title">4. ExceptionHandlingBehavior</div>
+        <div class="box-code">DB / SQL / Timeout exceptions</div>
+        <div class="box-desc">Transforms exceptions &rarr; Result.Conflict/Error</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="arrow-down">&darr; &uarr;<span class="arrow-label">Result&lt;T&gt;</span></div>
+
+  <!-- UseCases Layer -->
+  <div class="layer layer-usecases">
+    <span class="layer-label">Server.UseCases &mdash; Application (CQRS)</span>
+    <div class="layer-boxes">
+      <div class="box">
+        <div class="box-title">Commands (Mutations)</div>
+        <div class="box-code">ICommand&lt;T&gt; + ICommandHandler</div>
+        <div class="box-desc">Create, update, delete operations</div>
+      </div>
+      <div class="box">
+        <div class="box-title">Queries (Reads)</div>
+        <div class="box-code">IQuery&lt;T&gt; + IQueryHandler</div>
+        <div class="box-desc">Get, list, search with Specifications</div>
+      </div>
+      <div class="box">
+        <div class="box-title">Interfaces</div>
+        <div class="box-code">IUserContext, IEmailSender, etc.</div>
+        <div class="box-desc">Port definitions for infrastructure</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="arrow-down">&darr;<span class="arrow-label">uses domain entities &amp; specifications</span></div>
+
+  <!-- Core Layer -->
+  <div class="layer layer-core">
+    <span class="layer-label">Server.Core &mdash; Domain</span>
+    <div class="layer-boxes">
+      <div class="box">
+        <div class="box-title">Aggregate Roots</div>
+        <div class="box-code">Article, Author, Tag, User</div>
+        <div class="box-desc">Each in Server.Core.{Name}Aggregate namespace</div>
+      </div>
+      <div class="box">
+        <div class="box-title">Child Entities</div>
+        <div class="box-code">Comment, UserFollowing</div>
+        <div class="box-desc">Owned by aggregate roots</div>
+      </div>
+      <div class="box">
+        <div class="box-title">Specifications</div>
+        <div class="box-code">ArticleBySlugSpec, etc.</div>
+        <div class="box-desc">Ardalis.Specification query objects</div>
+      </div>
+      <div class="box">
+        <div class="box-title">Domain Events</div>
+        <div class="box-code">IDomainEvent : INotification</div>
+        <div class="box-desc">Collected in EntityBase, published post-commit</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="arrow-down">&darr;<span class="arrow-label">extends EntityBase, IAggregateRoot</span></div>
+
+  <!-- SharedKernel Layer -->
+  <div class="layer layer-shared">
+    <span class="layer-label">Server.SharedKernel &mdash; Contracts &amp; Abstractions</span>
+    <div class="layer-boxes">
+      <div class="box">
+        <div class="box-title">Result&lt;T&gt;</div>
+        <div class="box-code">Success | Created | Invalid | NotFound | Error | ...</div>
+        <div class="box-desc">Replace exceptions for control flow</div>
+      </div>
+      <div class="box">
+        <div class="box-title">IRepository&lt;T&gt;</div>
+        <div class="box-code">Add, Update, Delete, GetById, List</div>
+        <div class="box-desc">Constrained to IAggregateRoot</div>
+      </div>
+      <div class="box">
+        <div class="box-title">EntityBase</div>
+        <div class="box-code">Id, ChangeCheck, Created/Updated At/By</div>
+        <div class="box-desc">Base class with audit properties + concurrency token</div>
+      </div>
+      <div class="box">
+        <div class="box-title">MediatR Contracts</div>
+        <div class="box-code">ICommand&lt;T&gt;, IQuery&lt;T&gt;, IResultRequest&lt;T&gt;</div>
+        <div class="box-desc">Request hierarchy for CQRS</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="arrow-down">&darr;<span class="arrow-label">implemented by</span></div>
+
+  <!-- Infrastructure Layer -->
+  <div class="layer layer-infra">
+    <span class="layer-label">Server.Infrastructure &mdash; Data &amp; Services</span>
+    <div class="layer-boxes">
+      <div class="box">
+        <div class="box-title">EfRepository&lt;T&gt;</div>
+        <div class="box-code">Ardalis RepositoryBase&lt;T&gt;</div>
+        <div class="box-desc">Implements IRepository via EF Core</div>
+      </div>
+      <div class="box">
+        <div class="box-title">AppDbContext</div>
+        <div class="box-code">MultiTenantIdentityDbContext</div>
+        <div class="box-desc">Audit.NET interceptor, domain event dispatch</div>
+      </div>
+      <div class="box">
+        <div class="box-title">UnitOfWork</div>
+        <div class="box-code">ExecuteInTransactionAsync()</div>
+        <div class="box-desc">EF execution strategy + audit scope</div>
+      </div>
+      <div class="box">
+        <div class="box-title">Services</div>
+        <div class="box-code">UserContext, BcryptPasswordHasher<br>MimeKitEmailSender</div>
+        <div class="box-desc">Infrastructure service implementations</div>
+      </div>
+      <div class="box">
+        <div class="box-title">Domain Event Dispatcher</div>
+        <div class="box-code">MediatRDomainEventDispatcher</div>
+        <div class="box-desc">Publishes IDomainEvent via mediator.Publish()</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="arrow-down">&darr;<span class="arrow-label">persists to</span></div>
+
+  <!-- External Systems -->
+  <div class="layer layer-external">
+    <span class="layer-label">External Systems</span>
+    <div class="layer-boxes">
+      <div class="box" style="background:#21272a; color:#f4f4f4;">
+        <div class="box-title" style="color:#78a9ff;">SQL Server</div>
+        <div class="box-code" style="color:#a8a8a8;">Multi-tenant (Finbuckle)</div>
+        <div class="box-desc" style="color:#6f6f6f;">Query filters per tenant ID</div>
+      </div>
+      <div class="box" style="background:#21272a; color:#f4f4f4;">
+        <div class="box-title" style="color:#78a9ff;">Audit.NET</div>
+        <div class="box-code" style="color:#a8a8a8;">File-based audit logs</div>
+        <div class="box-desc" style="color:#6f6f6f;">Transaction-aware, correlation ID</div>
+      </div>
+      <div class="box" style="background:#21272a; color:#f4f4f4;">
+        <div class="box-title" style="color:#78a9ff;">OpenTelemetry</div>
+        <div class="box-code" style="color:#a8a8a8;">Jaeger &middot; Prometheus &middot; Seq</div>
+        <div class="box-desc" style="color:#6f6f6f;">Traces, metrics, structured logs</div>
+      </div>
+      <div class="box" style="background:#21272a; color:#f4f4f4;">
+        <div class="box-title" style="color:#78a9ff;">Azure</div>
+        <div class="box-code" style="color:#a8a8a8;">App Config &middot; Monitor &middot; App Service</div>
+        <div class="box-desc" style="color:#6f6f6f;">Feature flags, production telemetry</div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<div class="dep-rule">&larr; Dependencies point inward &rarr;</div>
+
+<!-- Legend -->
+<div class="legend">
+  <div class="legend-item"><span class="legend-dot" style="background:var(--web-bg);border-color:var(--web);"></span> Presentation (Web)</div>
+  <div class="legend-item"><span class="legend-dot" style="background:var(--mediator-bg);border-color:var(--mediator);"></span> Pipeline (MediatR)</div>
+  <div class="legend-item"><span class="legend-dot" style="background:var(--usecases-bg);border-color:var(--usecases);"></span> Application (UseCases)</div>
+  <div class="legend-item"><span class="legend-dot" style="background:var(--core-bg);border-color:var(--core);"></span> Domain (Core)</div>
+  <div class="legend-item"><span class="legend-dot" style="background:var(--shared-bg);border-color:var(--shared);"></span> Contracts (SharedKernel)</div>
+  <div class="legend-item"><span class="legend-dot" style="background:var(--infra-bg);border-color:var(--infra);"></span> Infrastructure</div>
+  <div class="legend-item"><span class="legend-dot" style="background:var(--external-bg);border-color:var(--external);"></span> External Systems</div>
+</div>
+
+<!-- Result Mapping Table -->
+<h2 style="margin-top:40px; font-size:18px;">Result&lt;T&gt; &rarr; HTTP Status Mapping</h2>
+<table class="result-table">
+  <thead>
+    <tr>
+      <th>Result Status</th>
+      <th>HTTP Code</th>
+      <th>When</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>Success</td><td class="http-2xx">200 OK</td><td>Successful read or update</td></tr>
+    <tr><td>Created</td><td class="http-2xx">201 Created</td><td>New resource created</td></tr>
+    <tr><td>NoContent</td><td class="http-2xx">204 No Content</td><td>Delete or void operation</td></tr>
+    <tr><td>Invalid</td><td class="http-4xx">400 Bad Request</td><td>Business rule validation failure</td></tr>
+    <tr><td>Unauthorized</td><td class="http-4xx">401 Unauthorized</td><td>Missing or invalid credentials</td></tr>
+    <tr><td>Forbidden</td><td class="http-4xx">403 Forbidden</td><td>Authenticated but not authorized</td></tr>
+    <tr><td>NotFound</td><td class="http-4xx">404 Not Found</td><td>Entity doesn't exist</td></tr>
+    <tr><td>Conflict</td><td class="http-4xx">409 Conflict</td><td>Concurrency or duplicate key</td></tr>
+    <tr><td>Error</td><td class="http-4xx">422 Unprocessable</td><td>Semantic error in request</td></tr>
+    <tr><td>CriticalError</td><td class="http-5xx">500 Internal</td><td>Unhandled exception</td></tr>
+    <tr><td>Unavailable</td><td class="http-5xx">503 Unavailable</td><td>Timeout or transient failure</td></tr>
+  </tbody>
+</table>
+
+<div class="note">
+  <strong>Dependency Rule:</strong> Inner layers (SharedKernel, Core) have zero knowledge of outer layers.
+  UseCases depends on Core + SharedKernel. Infrastructure implements SharedKernel interfaces.
+  Web depends on everything but is the composition root. This is enforced by project references and 35+ custom Roslyn analyzers.
+</div>
+
+</body>
+</html>

--- a/Docs/architecture-diagram.mermaid
+++ b/Docs/architecture-diagram.mermaid
@@ -1,0 +1,117 @@
+flowchart TB
+    subgraph CLIENT["Client"]
+        req["HTTP Request\nPOST /api/articles\nBearer Token / Cookie"]
+        res["HTTP Response\n200 / 201 / 400 / 404 / 422\nJSON Body"]
+    end
+
+    subgraph WEB["Server.Web - Presentation Layer"]
+        direction TB
+        MW["ASP.NET Middleware\nExceptionHandler, MultiTenant\nAuthentication, Authorization"]
+        FE["FastEndpoints\nEndpoint TRequest TResponse TMapper\nRoute matching, model binding"]
+        VAL["FluentValidation\nValidator TRequest\nReturns 400 on failure"]
+        SEND["Send.ResultMapperAsync\nMaps Result T to HTTP status"]
+        MAP["ResponseMapper\nDomain entity to DTO"]
+        GEH["GlobalExceptionHandler\nPost-processor, catches unhandled exceptions"]
+    end
+
+    subgraph MEDIATOR["MediatR Pipeline - Behaviors"]
+        direction TB
+        B1["1. TracingBehavior\nOpenTelemetry span via ActivitySource"]
+        B2["2. LoggingBehavior\nSerilog structured logging, elapsed ms"]
+        B3["3. TransactionBehavior\nICommand only, wraps in EF transaction\nIUnitOfWork.ExecuteInTransactionAsync"]
+        B4["4. ExceptionHandlingBehavior\nCatches DB/SQL/timeout exceptions\nTransforms to Result.Conflict / Error"]
+    end
+
+    subgraph USECASES["Server.UseCases - Application Layer CQRS"]
+        direction LR
+        CMD["ICommand T\n+ ICommandHandler\nMutations: create, update, delete"]
+        QRY["IQuery T\n+ IQueryHandler\nReads: get, list, search"]
+    end
+
+    subgraph CORE["Server.Core - Domain Layer"]
+        direction LR
+        AGG["Aggregate Roots\nArticle, Author, Tag, User\nEach in own Aggregate namespace"]
+        ENT["Child Entities\nComment, UserFollowing\nOwned by aggregate roots"]
+        SPEC["Specifications\nArticleBySlugSpec\nArdalis.Specification queries"]
+        EVT["Domain Events\nIDomainEvent\nPublished post-SaveChanges"]
+    end
+
+    subgraph SHARED["Server.SharedKernel - Contracts"]
+        direction LR
+        RES["Result T\nSuccess / Created / NoContent\nInvalid / NotFound / Error / ..."]
+        REPOI["IRepository T\nAdd, Update, Delete\nGetById, List, Count"]
+        BASE["EntityBase\nId, ChangeCheck, CreatedAt\nUpdatedAt, CreatedBy, UpdatedBy"]
+    end
+
+    subgraph INFRA["Server.Infrastructure - Data and Services"]
+        direction TB
+        REPO["EfRepository T\nArdalis RepositoryBase"]
+        UOW["UnitOfWork\nEF execution strategy + transaction"]
+        CTX["AppDbContext\nMultiTenantIdentityDbContext\nAuditDbContext"]
+        AUDINT["AuditableEntityInterceptor\nSets CreatedAt/UpdatedAt/By"]
+        DISP["MediatRDomainEventDispatcher\nPublishes events post-commit"]
+        UC["UserContext\nIUserContext: UserId, Username\nfrom ClaimsPrincipal"]
+    end
+
+    subgraph EXTERNAL["External Systems"]
+        direction LR
+        DB[("SQL Server\nMulti-tenant\nFinbuckle filtered")]
+        AUDIT["Audit.NET\nFile-based audit logs"]
+        OTEL["OpenTelemetry\nJaeger traces\nPrometheus metrics\nSeq logs"]
+    end
+
+    req --> MW
+    MW --> FE
+    FE --> VAL
+    VAL -->|Valid| SEND
+    VAL -->|Invalid 400| res
+    SEND -->|IMediator.Send| B1
+    B1 --> B2
+    B2 --> B3
+    B3 --> B4
+    B4 --> CMD
+    B4 --> QRY
+    CMD -->|Repository.AddAsync etc| REPO
+    QRY -->|Repository.ListAsync Spec| REPO
+    CMD -.->|uses| AGG
+    QRY -.->|uses| SPEC
+    AGG --- ENT
+    AGG --- EVT
+    AGG -.->|extends| BASE
+    REPOI -.->|implemented by| REPO
+    REPO --> CTX
+    CTX --> AUDINT
+    CTX --> DB
+    CTX -->|SaveChangesAsync| DISP
+    DISP -.->|mediator.Publish| EVT
+    UOW --> CTX
+    B3 -.->|uses| UOW
+    CTX --> AUDIT
+    B1 --> OTEL
+    CMD -->|Result T| B4
+    QRY -->|Result T| B4
+    B4 -->|Result T| B3
+    B3 -->|Result T| B2
+    B2 -->|Result T| B1
+    B1 -->|Result T| SEND
+    SEND --> MAP
+    MAP --> GEH
+    GEH --> res
+
+    classDef web fill:#4589ff,color:#fff,stroke:#0043ce
+    classDef mediator fill:#a56eff,color:#fff,stroke:#6929c4
+    classDef usecases fill:#0e6027,color:#fff,stroke:#044317
+    classDef core fill:#d4a017,color:#000,stroke:#8a6d3b
+    classDef shared fill:#6c757d,color:#fff,stroke:#495057
+    classDef infra fill:#d02670,color:#fff,stroke:#9f1853
+    classDef external fill:#343a3f,color:#fff,stroke:#21272a
+    classDef client fill:#f4f4f4,color:#161616,stroke:#8d8d8d
+
+    class MW,FE,VAL,SEND,MAP,GEH web
+    class B1,B2,B3,B4 mediator
+    class CMD,QRY usecases
+    class AGG,ENT,SPEC,EVT core
+    class RES,REPOI,BASE shared
+    class REPO,UOW,CTX,AUDINT,DISP,UC infra
+    class DB,AUDIT,OTEL external
+    class req,res client

--- a/Docs/architecture-diagram.txt
+++ b/Docs/architecture-diagram.txt
@@ -1,0 +1,162 @@
+
+    CONDUIT BACKEND ARCHITECTURE — Request Pipeline through Clean Architecture Layers
+    ==================================================================================
+
+    ┌─────────────────────────────────────────────────────────────────────────────────┐
+    │  CLIENT                                                                         │
+    │  HTTP Request (POST /api/articles, Bearer token / Cookie)                       │
+    └─────────────────────────────────┬───────────────────────────────────────────────┘
+                                      │ JSON over HTTPS
+                                      ▼
+    ┌─────────────────────────────────────────────────────────────────────────────────┐
+    │  SERVER.WEB — Presentation Layer                                      [blue]    │
+    │                                                                                 │
+    │  ┌──────────────────┐  ┌──────────────────┐  ┌───────────────────────────────┐  │
+    │  │ ASP.NET Middleware│  │ FastEndpoints    │  │ FluentValidation              │  │
+    │  │                  │  │                  │  │ Validator<TRequest>           │  │
+    │  │ ExceptionHandler │  │ Endpoint<TReq,   │  │ Auto-discovered               │  │
+    │  │ MultiTenant      │  │   TRes, TMapper> │  │ Invalid → 400 Bad Request     │  │
+    │  │ Authentication   │  │                  │  │                               │  │
+    │  │ Authorization    │  │ Route match,     │  │                               │  │
+    │  │ Antiforgery      │  │ model binding    │  │                               │  │
+    │  └──────────────────┘  └──────────────────┘  └───────────────────────────────┘  │
+    │                                                                                 │
+    │  ┌──────────────────────────────┐  ┌──────────────────────────────────────────┐  │
+    │  │ Send.ResultMapperAsync()     │  │ GlobalExceptionHandler (PostProcessor)   │  │
+    │  │ Maps Result<T> → HTTP status │  │ Last-resort exception → ProblemDetails   │  │
+    │  │ + ResponseMapper<TRes,TEnt>  │  │                                          │  │
+    │  └──────────────────────────────┘  └──────────────────────────────────────────┘  │
+    └─────────────────────────────────┬───────────────────────────────────────────────┘
+                                      │ IMediator.Send(command/query)
+                                      ▼
+    ┌─────────────────────────────────────────────────────────────────────────────────┐
+    │  MEDIATR PIPELINE — Behaviors (executed in order)                    [purple]    │
+    │                                                                                 │
+    │  ┌─────────────────────────────────────────────────────────────────────────────┐ │
+    │  │ 1. TracingBehavior          OpenTelemetry span (ActivitySource: Conduit.*)  │ │
+    │  ├─────────────────────────────────────────────────────────────────────────────┤ │
+    │  │ 2. LoggingBehavior          Serilog: {@Request}, elapsed ms, status        │ │
+    │  ├─────────────────────────────────────────────────────────────────────────────┤ │
+    │  │ 3. TransactionBehavior      ICommand only → IUnitOfWork transaction        │ │
+    │  │                             Commit on success, rollback on failure          │ │
+    │  ├─────────────────────────────────────────────────────────────────────────────┤ │
+    │  │ 4. ExceptionHandlingBehavior  DB/SQL/Timeout → Result.Conflict/Error       │ │
+    │  └─────────────────────────────────────────────────────────────────────────────┘ │
+    └─────────────────────────────────┬───────────────────────────────────────────────┘
+                                      │ Result<T>
+                                      ▼
+    ┌─────────────────────────────────────────────────────────────────────────────────┐
+    │  SERVER.USECASES — Application Layer (CQRS)                         [green]     │
+    │                                                                                 │
+    │  ┌───────────────────────────┐  ┌───────────────────────────┐                   │
+    │  │ ICommand<T>               │  │ IQuery<T>                 │                   │
+    │  │ + ICommandHandler         │  │ + IQueryHandler           │                   │
+    │  │                           │  │                           │                   │
+    │  │ Mutations:                │  │ Reads:                    │                   │
+    │  │ create, update, delete    │  │ get, list, search         │                   │
+    │  │                           │  │                           │                   │
+    │  │ MUST call repository      │  │ Uses Specifications       │                   │
+    │  │ mutation (PV014 enforced) │  │ (Ardalis.Specification)   │                   │
+    │  └───────────────────────────┘  └───────────────────────────┘                   │
+    └──────────────────┬──────────────────────────────┬───────────────────────────────┘
+                       │ uses domain entities          │ IRepository<T>.ListAsync(spec)
+                       ▼                               ▼
+    ┌─────────────────────────────────────────────────────────────────────────────────┐
+    │  SERVER.CORE — Domain Layer                                         [gold]      │
+    │                                                                                 │
+    │  ┌─────────────────┐  ┌─────────────────┐  ┌──────────────┐  ┌──────────────┐  │
+    │  │ Aggregate Roots  │  │ Child Entities  │  │Specifications│  │Domain Events │  │
+    │  │                  │  │                  │  │              │  │              │  │
+    │  │ Article          │  │ Comment          │  │ ArticleBy-   │  │ IDomainEvent │  │
+    │  │ Author           │  │ UserFollowing    │  │   SlugSpec   │  │ : INotifi-   │  │
+    │  │ Tag              │  │                  │  │ AuthorBy-    │  │   cation     │  │
+    │  │ User             │  │ (owned by agg    │  │   UserIdSpec │  │              │  │
+    │  │                  │  │  roots)          │  │              │  │ Published    │  │
+    │  │ Each in own      │  │                  │  │              │  │ post-commit  │  │
+    │  │ *Aggregate ns    │  │                  │  │              │  │              │  │
+    │  └─────────────────┘  └─────────────────┘  └──────────────┘  └──────────────┘  │
+    └─────────────────────────────────┬───────────────────────────────────────────────┘
+                                      │ extends EntityBase, IAggregateRoot
+                                      ▼
+    ┌─────────────────────────────────────────────────────────────────────────────────┐
+    │  SERVER.SHAREDKERNEL — Contracts & Abstractions                      [gray]     │
+    │                                                                                 │
+    │  ┌─────────────────┐  ┌─────────────────┐  ┌──────────────┐  ┌──────────────┐  │
+    │  │ Result<T>        │  │ IRepository<T>  │  │ EntityBase   │  │ MediatR      │  │
+    │  │                  │  │                  │  │              │  │ Contracts    │  │
+    │  │ Success          │  │ Add/Update/     │  │ Id (Guid)    │  │              │  │
+    │  │ Created          │  │ Delete          │  │ ChangeCheck  │  │ ICommand<T>  │  │
+    │  │ NoContent        │  │ GetById/List/   │  │ CreatedAt    │  │ IQuery<T>    │  │
+    │  │ Invalid          │  │ Count           │  │ UpdatedAt    │  │ IResult-     │  │
+    │  │ NotFound         │  │                  │  │ CreatedBy    │  │   Request<T> │  │
+    │  │ Error            │  │ Constrained to  │  │ UpdatedBy    │  │              │  │
+    │  │ Conflict         │  │ IAggregateRoot  │  │              │  │              │  │
+    │  │ CriticalError    │  │                  │  │              │  │              │  │
+    │  │ Unavailable      │  │                  │  │              │  │              │  │
+    │  └─────────────────┘  └─────────────────┘  └──────────────┘  └──────────────┘  │
+    └─────────────────────────────────┬───────────────────────────────────────────────┘
+                                      │ implemented by
+                                      ▼
+    ┌─────────────────────────────────────────────────────────────────────────────────┐
+    │  SERVER.INFRASTRUCTURE — Data & Services                             [pink]     │
+    │                                                                                 │
+    │  ┌─────────────────┐  ┌─────────────────┐  ┌──────────────┐  ┌──────────────┐  │
+    │  │ EfRepository<T> │  │ AppDbContext     │  │ UnitOfWork   │  │ Services     │  │
+    │  │                  │  │                  │  │              │  │              │  │
+    │  │ Ardalis          │  │ MultiTenant-     │  │ ExecuteIn-   │  │ UserContext  │  │
+    │  │ RepositoryBase   │  │ IdentityDb-      │  │ Transaction- │  │ BcryptHash  │  │
+    │  │                  │  │ Context          │  │ Async()      │  │ EmailSender │  │
+    │  │ Implements       │  │                  │  │              │  │              │  │
+    │  │ IRepository<T>  │  │ [AuditDbContext]  │  │ EF execution │  │ DomainEvent │  │
+    │  │                  │  │ DomainEvent      │  │ strategy +   │  │ Dispatcher  │  │
+    │  │                  │  │ dispatch         │  │ audit scope  │  │ (MediatR)   │  │
+    │  └─────────────────┘  └─────────────────┘  └──────────────┘  └──────────────┘  │
+    └─────────────────────────────────┬───────────────────────────────────────────────┘
+                                      │ persists to
+                                      ▼
+    ┌─────────────────────────────────────────────────────────────────────────────────┐
+    │  EXTERNAL SYSTEMS                                                    [dark]     │
+    │                                                                                 │
+    │  ┌─────────────────┐  ┌─────────────────┐  ┌──────────────┐  ┌──────────────┐  │
+    │  │ SQL Server       │  │ Audit.NET       │  │ OpenTelemetry│  │ Azure        │  │
+    │  │                  │  │                  │  │              │  │              │  │
+    │  │ Multi-tenant     │  │ File-based      │  │ → Jaeger     │  │ App Config   │  │
+    │  │ (Finbuckle)      │  │ audit logs      │  │   (traces)   │  │ (feat flags) │  │
+    │  │                  │  │                  │  │ → Prometheus │  │              │  │
+    │  │ Query filters    │  │ Transaction-     │  │   (metrics)  │  │ Monitor      │  │
+    │  │ per tenant ID    │  │ aware, with      │  │ → Seq        │  │ (prod telem) │  │
+    │  │                  │  │ correlation ID   │  │   (logs)     │  │              │  │
+    │  └─────────────────┘  └─────────────────┘  └──────────────┘  └──────────────┘  │
+    └─────────────────────────────────────────────────────────────────────────────────┘
+
+
+    RESULT<T> → HTTP STATUS MAPPING
+    ════════════════════════════════
+
+    Result Status     HTTP Code              When
+    ─────────────     ─────────              ────
+    Success           200 OK                 Successful read or update
+    Created           201 Created            New resource created
+    NoContent         204 No Content         Delete or void operation
+    Invalid           400 Bad Request        Business rule validation failure
+    Unauthorized      401 Unauthorized       Missing or invalid credentials
+    Forbidden         403 Forbidden          Authenticated but not authorized
+    NotFound          404 Not Found          Entity doesn't exist
+    Conflict          409 Conflict           Concurrency or duplicate key
+    Error             422 Unprocessable      Semantic error in request
+    CriticalError     500 Internal           Unhandled exception
+    Unavailable       503 Service Unavail.   Timeout or transient failure
+
+
+    DEPENDENCY RULE
+    ═══════════════
+
+    Dependencies point INWARD only. Enforced by project references + 35 Roslyn analyzers.
+
+         Web ──→ UseCases ──→ Core ──→ SharedKernel
+          │          │                      ▲
+          │          └──────────────────────┘
+          │                                 ▲
+          └──→ Infrastructure ──────────────┘
+               (implements SharedKernel interfaces)
+

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Server.Analyzers         — 32 custom Roslyn analyzers (SRV + PV series)
 
 Endpoints are thin: bind request -> authorize -> delegate to MediatR -> map response. Business rules live in handlers. Persistence is abstracted behind repository interfaces.
 
+[View the full architecture diagram](Docs/architecture-diagram.html) for a visual walkthrough of the request pipeline and all layers.
+
 **Cross-cutting concerns:**
 - **Serilog** — structured logging with enrichers, file sinks, and Seq integration
 - **Audit.NET** — automatic audit trails for EF Core entity changes and Identity operations


### PR DESCRIPTION
## Summary
- Adds an interactive HTML architecture diagram showing the request pipeline through all Clean Architecture layers, plus mermaid and ASCII versions
- Links the diagram from README.md for easy discovery

## Test plan
- [ ] Verify `Docs/architecture-diagram.html` renders correctly when opened in a browser
- [ ] Verify the README link navigates to the diagram

🤖 Generated with [Claude Code](https://claude.com/claude-code)