### PR TITLE
docs: add backend architecture diagram

### DIFF
--- a/Docs/architecture-diagram.html
+++ b/Docs/architecture-diagram.html
@@ -1,0 +1,555 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Backend Architecture</title>
+<style>
+  :root {
+    --web: #4589ff;
+    --web-bg: #edf5ff;
+    --mediator: #a56eff;
+    --mediator-bg: #f6f2ff;
+    --usecases: #0e6027;
+    --usecases-bg: #defbe6;
+    --core: #b28600;
+    --core-bg: #fff8e1;
+    --shared: #6c757d;
+    --shared-bg: #f4f4f4;
+    --infra: #d02670;
+    --infra-bg: #fff0f7;
+    --external: #343a3f;
+    --external-bg: #e8e8e8;
+    --arrow: #525252;
+    --bg: #ffffff;
+    --text: #161616;
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  body {
+    font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    padding: 32px;
+    line-height: 1.5;
+  }
+
+  h1 {
+    font-size: 28px;
+    font-weight: 600;
+    margin-bottom: 8px;
+  }
+
+  .subtitle {
+    color: #525252;
+    font-size: 14px;
+    margin-bottom: 32px;
+  }
+
+  .diagram {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    max-width: 1100px;
+    margin: 0 auto;
+    position: relative;
+  }
+
+  /* Layer rows */
+  .layer {
+    border: 2px solid;
+    border-radius: 8px;
+    padding: 16px 20px;
+    position: relative;
+    margin-bottom: 16px;
+  }
+
+  .layer-label {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+    position: absolute;
+    top: -10px;
+    left: 16px;
+    padding: 0 8px;
+  }
+
+  .layer-boxes {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-top: 4px;
+  }
+
+  .box {
+    background: white;
+    border: 1.5px solid;
+    border-radius: 6px;
+    padding: 10px 14px;
+    flex: 1;
+    min-width: 180px;
+  }
+
+  .box-title {
+    font-size: 13px;
+    font-weight: 600;
+    margin-bottom: 4px;
+  }
+
+  .box-code {
+    font-family: 'IBM Plex Mono', 'Fira Code', monospace;
+    font-size: 11px;
+    color: #525252;
+    margin-bottom: 2px;
+  }
+
+  .box-desc {
+    font-size: 11px;
+    color: #6f6f6f;
+    font-style: italic;
+  }
+
+  /* Arrow between layers */
+  .arrow-down {
+    text-align: center;
+    font-size: 22px;
+    color: var(--arrow);
+    margin: -8px 0;
+    z-index: 1;
+    position: relative;
+  }
+
+  .arrow-label {
+    font-size: 10px;
+    color: #6f6f6f;
+    font-family: 'IBM Plex Mono', monospace;
+    vertical-align: middle;
+    margin-left: 8px;
+  }
+
+  /* Layer colors */
+  .layer-client { border-color: #8d8d8d; background: #f9f9f9; }
+  .layer-client .layer-label { background: #f9f9f9; color: #525252; }
+
+  .layer-web { border-color: var(--web); background: var(--web-bg); }
+  .layer-web .layer-label { background: var(--web-bg); color: var(--web); }
+  .layer-web .box { border-color: var(--web); }
+  .layer-web .box-title { color: var(--web); }
+
+  .layer-mediator { border-color: var(--mediator); background: var(--mediator-bg); }
+  .layer-mediator .layer-label { background: var(--mediator-bg); color: var(--mediator); }
+  .layer-mediator .box { border-color: var(--mediator); }
+  .layer-mediator .box-title { color: var(--mediator); }
+
+  .layer-usecases { border-color: var(--usecases); background: var(--usecases-bg); }
+  .layer-usecases .layer-label { background: var(--usecases-bg); color: var(--usecases); }
+  .layer-usecases .box { border-color: var(--usecases); }
+  .layer-usecases .box-title { color: var(--usecases); }
+
+  .layer-core { border-color: var(--core); background: var(--core-bg); }
+  .layer-core .layer-label { background: var(--core-bg); color: var(--core); }
+  .layer-core .box { border-color: var(--core); }
+  .layer-core .box-title { color: var(--core); }
+
+  .layer-shared { border-color: var(--shared); background: var(--shared-bg); }
+  .layer-shared .layer-label { background: var(--shared-bg); color: var(--shared); }
+  .layer-shared .box { border-color: var(--shared); }
+  .layer-shared .box-title { color: var(--shared); }
+
+  .layer-infra { border-color: var(--infra); background: var(--infra-bg); }
+  .layer-infra .layer-label { background: var(--infra-bg); color: var(--infra); }
+  .layer-infra .box { border-color: var(--infra); }
+  .layer-infra .box-title { color: var(--infra); }
+
+  .layer-external { border-color: var(--external); background: var(--external-bg); }
+  .layer-external .layer-label { background: var(--external-bg); color: var(--external); }
+  .layer-external .box { border-color: var(--external); }
+  .layer-external .box-title { color: var(--external); }
+
+  /* Dependency rule sidebar */
+  .dep-rule {
+    position: fixed;
+    right: 32px;
+    top: 50%;
+    transform: translateY(-50%);
+    writing-mode: vertical-lr;
+    text-orientation: mixed;
+    font-size: 11px;
+    color: #a8a8a8;
+    letter-spacing: 2px;
+    font-weight: 600;
+    text-transform: uppercase;
+  }
+
+  .dep-rule::before {
+    content: '';
+    display: block;
+    width: 1.5px;
+    height: 80px;
+    background: #c6c6c6;
+    margin: 0 auto 8px;
+  }
+
+  .dep-rule::after {
+    content: '';
+    display: block;
+    width: 1.5px;
+    height: 80px;
+    background: #c6c6c6;
+    margin: 8px auto 0;
+  }
+
+  /* Legend */
+  .legend {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin-top: 24px;
+    padding-top: 16px;
+    border-top: 1px solid #e0e0e0;
+  }
+
+  .legend-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 11px;
+  }
+
+  .legend-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 3px;
+    border: 1.5px solid;
+  }
+
+  /* Result mapping table */
+  .result-table {
+    margin-top: 32px;
+    border-collapse: collapse;
+    font-size: 13px;
+    width: 100%;
+    max-width: 700px;
+  }
+
+  .result-table th {
+    text-align: left;
+    padding: 8px 12px;
+    border-bottom: 2px solid #e0e0e0;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: #525252;
+  }
+
+  .result-table td {
+    padding: 6px 12px;
+    border-bottom: 1px solid #f0f0f0;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 12px;
+  }
+
+  .result-table tr:hover { background: #f9f9f9; }
+
+  .http-2xx { color: #198038; font-weight: 600; }
+  .http-4xx { color: #da1e28; font-weight: 600; }
+  .http-5xx { color: #6929c4; font-weight: 600; }
+
+  .note {
+    margin-top: 24px;
+    padding: 12px 16px;
+    background: #f4f4f4;
+    border-left: 3px solid #8d8d8d;
+    font-size: 12px;
+    color: #525252;
+  }
+
+  @media (max-width: 768px) {
+    body { padding: 16px; }
+    .box { min-width: 140px; }
+    .dep-rule { display: none; }
+  }
+</style>
+</head>
+<body>
+
+<h1>Backend Architecture</h1>
+<p class="subtitle">Ardalis Clean Architecture &middot; .NET 10 &middot; FastEndpoints &middot; MediatR CQRS &middot; EF Core</p>
+
+<div class="diagram">
+
+  <!-- Client -->
+  <div class="layer layer-client">
+    <span class="layer-label">Client</span>
+    <div class="layer-boxes">
+      <div class="box">
+        <div class="box-title">HTTP Request</div>
+        <div class="box-code">POST /api/articles</div>
+        <div class="box-desc">Bearer token or cookie authentication</div>
+      </div>
+      <div class="box">
+        <div class="box-title">HTTP Response</div>
+        <div class="box-code">200 / 201 / 400 / 404 / 422</div>
+        <div class="box-desc">JSON body with ProblemDetails on error</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="arrow-down">&darr; &uarr;<span class="arrow-label">JSON over HTTPS</span></div>
+
+  <!-- Web Layer -->
+  <div class="layer layer-web">
+    <span class="layer-label">Server.Web &mdash; Presentation</span>
+    <div class="layer-boxes">
+      <div class="box">
+        <div class="box-title">ASP.NET Middleware</div>
+        <div class="box-code">UseExceptionHandler &rarr; UseMultiTenant<br>&rarr; UseAuth &rarr; UseAuthorization</div>
+        <div class="box-desc">Finbuckle tenant resolution from __tenant__ claim</div>
+      </div>
+      <div class="box">
+        <div class="box-title">FastEndpoints</div>
+        <div class="box-code">Endpoint&lt;TReq, TRes, TMapper&gt;</div>
+        <div class="box-desc">Route matching, model binding, authorization</div>
+      </div>
+      <div class="box">
+        <div class="box-title">FluentValidation</div>
+        <div class="box-code">Validator&lt;TRequest&gt;</div>
+        <div class="box-desc">Auto-discovered; returns 400 on failure</div>
+      </div>
+      <div class="box">
+        <div class="box-title">Response Mapping</div>
+        <div class="box-code">Send.ResultMapperAsync()</div>
+        <div class="box-desc">Result&lt;T&gt; &rarr; HTTP status + ResponseMapper</div>
+      </div>
+      <div class="box">
+        <div class="box-title">GlobalExceptionHandler</div>
+        <div class="box-code">IGlobalPostProcessor</div>
+        <div class="box-desc">Last-resort exception &rarr; ProblemDetails</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="arrow-down">&darr; &uarr;<span class="arrow-label">IMediator.Send(command/query)</span></div>
+
+  <!-- MediatR Pipeline -->
+  <div class="layer layer-mediator">
+    <span class="layer-label">MediatR Pipeline &mdash; Behaviors (ordered)</span>
+    <div class="layer-boxes">
+      <div class="box">
+        <div class="box-title">1. TracingBehavior</div>
+        <div class="box-code">ActivitySource: App.MediatR</div>
+        <div class="box-desc">OpenTelemetry span per request</div>
+      </div>
+      <div class="box">
+        <div class="box-title">2. LoggingBehavior</div>
+        <div class="box-code">Serilog {@Request}, elapsed ms</div>
+        <div class="box-desc">Structured logging with Stopwatch</div>
+      </div>
+      <div class="box">
+        <div class="box-title">3. TransactionBehavior</div>
+        <div class="box-code">IUnitOfWork (ICommand only)</div>
+        <div class="box-desc">EF transaction; commit on success, rollback on failure</div>
+      </div>
+      <div class="box">
+        <div class="box-title">4. ExceptionHandlingBehavior</div>
+        <div class="box-code">DB / SQL / Timeout exceptions</div>
+        <div class="box-desc">Transforms exceptions &rarr; Result.Conflict/Error</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="arrow-down">&darr; &uarr;<span class="arrow-label">Result&lt;T&gt;</span></div>
+
+  <!-- UseCases Layer -->
+  <div class="layer layer-usecases">
+    <span class="layer-label">Server.UseCases &mdash; Application (CQRS)</span>
+    <div class="layer-boxes">
+      <div class="box">
+        <div class="box-title">Commands (Mutations)</div>
+        <div class="box-code">ICommand&lt;T&gt; + ICommandHandler</div>
+        <div class="box-desc">Create, update, delete operations</div>
+      </div>
+      <div class="box">
+        <div class="box-title">Queries (Reads)</div>
+        <div class="box-code">IQuery&lt;T&gt; + IQueryHandler</div>
+        <div class="box-desc">Get, list, search with Specifications</div>
+      </div>
+      <div class="box">
+        <div class="box-title">Interfaces</div>
+        <div class="box-code">IUserContext, IEmailSender, etc.</div>
+        <div class="box-desc">Port definitions for infrastructure</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="arrow-down">&darr;<span class="arrow-label">uses domain entities &amp; specifications</span></div>
+
+  <!-- Core Layer -->
+  <div class="layer layer-core">
+    <span class="layer-label">Server.Core &mdash; Domain</span>
+    <div class="layer-boxes">
+      <div class="box">
+        <div class="box-title">Aggregate Roots</div>
+        <div class="box-code">Article, Author, Tag, User</div>
+        <div class="box-desc">Each in Server.Core.{Name}Aggregate namespace</div>
+      </div>
+      <div class="box">
+        <div class="box-title">Child Entities</div>
+        <div class="box-code">Comment, UserFollowing</div>
+        <div class="box-desc">Owned by aggregate roots</div>
+      </div>
+      <div class="box">
+        <div class="box-title">Specifications</div>
+        <div class="box-code">ArticleBySlugSpec, etc.</div>
+        <div class="box-desc">Ardalis.Specification query objects</div>
+      </div>
+      <div class="box">
+        <div class="box-title">Domain Events</div>
+        <div class="box-code">IDomainEvent : INotification</div>
+        <div class="box-desc">Collected in EntityBase, published post-commit</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="arrow-down">&darr;<span class="arrow-label">extends EntityBase, IAggregateRoot</span></div>
+
+  <!-- SharedKernel Layer -->
+  <div class="layer layer-shared">
+    <span class="layer-label">Server.SharedKernel &mdash; Contracts &amp; Abstractions</span>
+    <div class="layer-boxes">
+      <div class="box">
+        <div class="box-title">Result&lt;T&gt;</div>
+        <div class="box-code">Success | Created | Invalid | NotFound | Error | ...</div>
+        <div class="box-desc">Replace exceptions for control flow</div>
+      </div>
+      <div class="box">
+        <div class="box-title">IRepository&lt;T&gt;</div>
+        <div class="box-code">Add, Update, Delete, GetById, List</div>
+        <div class="box-desc">Constrained to IAggregateRoot</div>
+      </div>
+      <div class="box">
+        <div class="box-title">EntityBase</div>
+        <div class="box-code">Id, ChangeCheck, Created/Updated At/By</div>
+        <div class="box-desc">Base class with audit properties + concurrency token</div>
+      </div>
+      <div class="box">
+        <div class="box-title">MediatR Contracts</div>
+        <div class="box-code">ICommand&lt;T&gt;, IQuery&lt;T&gt;, IResultRequest&lt;T&gt;</div>
+        <div class="box-desc">Request hierarchy for CQRS</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="arrow-down">&darr;<span class="arrow-label">implemented by</span></div>
+
+  <!-- Infrastructure Layer -->
+  <div class="layer layer-infra">
+    <span class="layer-label">Server.Infrastructure &mdash; Data &amp; Services</span>
+    <div class="layer-boxes">
+      <div class="box">
+        <div class="box-title">EfRepository&lt;T&gt;</div>
+        <div class="box-code">Ardalis RepositoryBase&lt;T&gt;</div>
+        <div class="box-desc">Implements IRepository via EF Core</div>
+      </div>
+      <div class="box">
+        <div class="box-title">AppDbContext</div>
+        <div class="box-code">MultiTenantIdentityDbContext</div>
+        <div class="box-desc">Audit.NET interceptor, domain event dispatch</div>
+      </div>
+      <div class="box">
+        <div class="box-title">UnitOfWork</div>
+        <div class="box-code">ExecuteInTransactionAsync()</div>
+        <div class="box-desc">EF execution strategy + audit scope</div>
+      </div>
+      <div class="box">
+        <div class="box-title">Services</div>
+        <div class="box-code">UserContext, BcryptPasswordHasher<br>MimeKitEmailSender</div>
+        <div class="box-desc">Infrastructure service implementations</div>
+      </div>
+      <div class="box">
+        <div class="box-title">Domain Event Dispatcher</div>
+        <div class="box-code">MediatRDomainEventDispatcher</div>
+        <div class="box-desc">Publishes IDomainEvent via mediator.Publish()</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="arrow-down">&darr;<span class="arrow-label">persists to</span></div>
+
+  <!-- External Systems -->
+  <div class="layer layer-external">
+    <span class="layer-label">External Systems</span>
+    <div class="layer-boxes">
+      <div class="box" style="background:#21272a; color:#f4f4f4;">
+        <div class="box-title" style="color:#78a9ff;">SQL Server</div>
+        <div class="box-code" style="color:#a8a8a8;">Multi-tenant (Finbuckle)</div>
+        <div class="box-desc" style="color:#6f6f6f;">Query filters per tenant ID</div>
+      </div>
+      <div class="box" style="background:#21272a; color:#f4f4f4;">
+        <div class="box-title" style="color:#78a9ff;">Audit.NET</div>
+        <div class="box-code" style="color:#a8a8a8;">File-based audit logs</div>
+        <div class="box-desc" style="color:#6f6f6f;">Transaction-aware, correlation ID</div>
+      </div>
+      <div class="box" style="background:#21272a; color:#f4f4f4;">
+        <div class="box-title" style="color:#78a9ff;">OpenTelemetry</div>
+        <div class="box-code" style="color:#a8a8a8;">Jaeger &middot; Prometheus &middot; Seq</div>
+        <div class="box-desc" style="color:#6f6f6f;">Traces, metrics, structured logs</div>
+      </div>
+      <div class="box" style="background:#21272a; color:#f4f4f4;">
+        <div class="box-title" style="color:#78a9ff;">Azure</div>
+        <div class="box-code" style="color:#a8a8a8;">App Config &middot; Monitor &middot; App Service</div>
+        <div class="box-desc" style="color:#6f6f6f;">Feature flags, production telemetry</div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<div class="dep-rule">&larr; Dependencies point inward &rarr;</div>
+
+<!-- Legend -->
+<div class="legend">
+  <div class="legend-item"><span class="legend-dot" style="background:var(--web-bg);border-color:var(--web);"></span> Presentation (Web)</div>
+  <div class="legend-item"><span class="legend-dot" style="background:var(--mediator-bg);border-color:var(--mediator);"></span> Pipeline (MediatR)</div>
+  <div class="legend-item"><span class="legend-dot" style="background:var(--usecases-bg);border-color:var(--usecases);"></span> Application (UseCases)</div>
+  <div class="legend-item"><span class="legend-dot" style="background:var(--core-bg);border-color:var(--core);"></span> Domain (Core)</div>
+  <div class="legend-item"><span class="legend-dot" style="background:var(--shared-bg);border-color:var(--shared);"></span> Contracts (SharedKernel)</div>
+  <div class="legend-item"><span class="legend-dot" style="background:var(--infra-bg);border-color:var(--infra);"></span> Infrastructure</div>
+  <div class="legend-item"><span class="legend-dot" style="background:var(--external-bg);border-color:var(--external);"></span> External Systems</div>
+</div>
+
+<!-- Result Mapping Table -->
+<h2 style="margin-top:40px; font-size:18px;">Result&lt;T&gt; &rarr; HTTP Status Mapping</h2>
+<table class="result-table">
+  <thead>
+    <tr>
+      <th>Result Status</th>
+      <th>HTTP Code</th>
+      <th>When</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td>Success</td><td class="http-2xx">200 OK</td><td>Successful read or update</td></tr>
+    <tr><td>Created</td><td class="http-2xx">201 Created</td><td>New resource created</td></tr>
+    <tr><td>NoContent</td><td class="http-2xx">204 No Content</td><td>Delete or void operation</td></tr>
+    <tr><td>Invalid</td><td class="http-4xx">400 Bad Request</td><td>Business rule validation failure</td></tr>
+    <tr><td>Unauthorized</td><td class="http-4xx">401 Unauthorized</td><td>Missing or invalid credentials</td></tr>
+    <tr><td>Forbidden</td><td class="http-4xx">403 Forbidden</td><td>Authenticated but not authorized</td></tr>
+    <tr><td>NotFound</td><td class="http-4xx">404 Not Found</td><td>Entity doesn't exist</td></tr>
+    <tr><td>Conflict</td><td class="http-4xx">409 Conflict</td><td>Concurrency or duplicate key</td></tr>
+    <tr><td>Error</td><td class="http-4xx">422 Unprocessable</td><td>Semantic error in request</td></tr>
+    <tr><td>CriticalError</td><td class="http-5xx">500 Internal</td><td>Unhandled exception</td></tr>
+    <tr><td>Unavailable</td><td class="http-5xx">503 Unavailable</td><td>Timeout or transient failure</td></tr>
+  </tbody>
+</table>
+
+<div class="note">
+  <strong>Dependency Rule:</strong> Inner layers (SharedKernel, Core) have zero knowledge of outer layers.
+  UseCases depends on Core + SharedKernel. Infrastructure implements SharedKernel interfaces.
+  Web depends on everything but is the composition root. This is enforced by project references and 35+ custom Roslyn analyzers.
+</div>
+
+</body>
+</html>

--- a/Docs/architecture-diagram.svg
+++ b/Docs/architecture-diagram.svg
@@ -1,0 +1,351 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 1580" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
+  <style>
+    .layer-label { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 1.2px; }
+    .box-title { font-size: 12px; font-weight: 600; }
+    .box-code { font-size: 10px; fill: #525252; font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; }
+    .box-desc { font-size: 10px; fill: #6f6f6f; font-style: italic; }
+    .arrow-label { font-size: 9px; fill: #6f6f6f; font-family: 'SF Mono', monospace; }
+    .arrow { font-size: 18px; fill: #525252; }
+    .heading { font-size: 24px; font-weight: 600; fill: #161616; }
+    .subtitle { font-size: 12px; fill: #525252; }
+    .table-header { font-size: 10px; font-weight: 600; fill: #525252; text-transform: uppercase; letter-spacing: 0.8px; }
+    .table-cell { font-size: 11px; font-family: 'SF Mono', 'Consolas', monospace; }
+    .http-2xx { fill: #198038; font-weight: 600; }
+    .http-4xx { fill: #da1e28; font-weight: 600; }
+    .http-5xx { fill: #6929c4; font-weight: 600; }
+    .note { font-size: 11px; fill: #525252; }
+    .note-bold { font-size: 11px; fill: #525252; font-weight: 700; }
+    .legend-text { font-size: 10px; fill: #161616; }
+  </style>
+
+  <!-- Title -->
+  <text x="20" y="30" class="heading">Backend Architecture</text>
+  <text x="20" y="50" class="subtitle">Ardalis Clean Architecture · .NET 10 · FastEndpoints · MediatR CQRS · EF Core</text>
+
+  <!-- ==================== CLIENT ==================== -->
+  <rect x="200" y="70" width="700" height="70" rx="8" fill="#f9f9f9" stroke="#8d8d8d" stroke-width="2"/>
+  <rect x="210" y="58" width="50" height="14" fill="#f9f9f9"/>
+  <text x="215" y="68" class="layer-label" fill="#525252">CLIENT</text>
+  <!-- Request box -->
+  <rect x="220" y="82" width="320" height="48" rx="5" fill="white" stroke="#8d8d8d" stroke-width="1.5"/>
+  <text x="232" y="98" class="box-title" fill="#161616">HTTP Request</text>
+  <text x="232" y="112" class="box-code">POST /api/articles</text>
+  <text x="232" y="124" class="box-desc">Bearer token or cookie authentication</text>
+  <!-- Response box -->
+  <rect x="560" y="82" width="320" height="48" rx="5" fill="white" stroke="#8d8d8d" stroke-width="1.5"/>
+  <text x="572" y="98" class="box-title" fill="#161616">HTTP Response</text>
+  <text x="572" y="112" class="box-code">200 / 201 / 400 / 404 / 422</text>
+  <text x="572" y="124" class="box-desc">JSON body with ProblemDetails on error</text>
+
+  <!-- Arrow -->
+  <text x="520" y="160" text-anchor="middle" class="arrow">&#8595; &#8593;</text>
+  <text x="580" y="158" class="arrow-label">JSON over HTTPS</text>
+
+  <!-- ==================== WEB LAYER ==================== -->
+  <rect x="40" y="170" width="1020" height="130" rx="8" fill="#edf5ff" stroke="#4589ff" stroke-width="2"/>
+  <rect x="50" y="158" width="215" height="14" fill="#edf5ff"/>
+  <text x="55" y="168" class="layer-label" fill="#4589ff">SERVER.WEB — PRESENTATION</text>
+  <!-- Middleware -->
+  <rect x="55" y="184" width="190" height="56" rx="5" fill="white" stroke="#4589ff" stroke-width="1.5"/>
+  <text x="65" y="198" class="box-title" fill="#4589ff">ASP.NET Middleware</text>
+  <text x="65" y="212" class="box-code">ExceptionHandler → MultiTenant</text>
+  <text x="65" y="224" class="box-code">→ Auth → Authorization</text>
+  <text x="65" y="236" class="box-desc">Finbuckle tenant from __tenant__ claim</text>
+  <!-- FastEndpoints -->
+  <rect x="255" y="184" width="190" height="56" rx="5" fill="white" stroke="#4589ff" stroke-width="1.5"/>
+  <text x="265" y="198" class="box-title" fill="#4589ff">FastEndpoints</text>
+  <text x="265" y="212" class="box-code">Endpoint&lt;TReq, TRes, TMapper&gt;</text>
+  <text x="265" y="226" class="box-desc">Route matching, model binding</text>
+  <!-- FluentValidation -->
+  <rect x="455" y="184" width="170" height="56" rx="5" fill="white" stroke="#4589ff" stroke-width="1.5"/>
+  <text x="465" y="198" class="box-title" fill="#4589ff">FluentValidation</text>
+  <text x="465" y="212" class="box-code">Validator&lt;TRequest&gt;</text>
+  <text x="465" y="226" class="box-desc">Auto-discovered; 400 on failure</text>
+  <!-- Response Mapping -->
+  <rect x="635" y="184" width="195" height="56" rx="5" fill="white" stroke="#4589ff" stroke-width="1.5"/>
+  <text x="645" y="198" class="box-title" fill="#4589ff">Response Mapping</text>
+  <text x="645" y="212" class="box-code">Send.ResultMapperAsync()</text>
+  <text x="645" y="226" class="box-desc">Result&lt;T&gt; → HTTP status</text>
+  <!-- GlobalExceptionHandler -->
+  <rect x="840" y="184" width="205" height="56" rx="5" fill="white" stroke="#4589ff" stroke-width="1.5"/>
+  <text x="850" y="198" class="box-title" fill="#4589ff">GlobalExceptionHandler</text>
+  <text x="850" y="212" class="box-code">IGlobalPostProcessor</text>
+  <text x="850" y="226" class="box-desc">Last-resort → ProblemDetails</text>
+
+  <!-- Row 2: Web extra boxes -->
+  <rect x="55" y="248" width="190" height="40" rx="5" fill="white" stroke="#4589ff" stroke-width="1.5"/>
+  <text x="65" y="263" class="box-title" fill="#4589ff">ResponseMapper</text>
+  <text x="65" y="278" class="box-desc">Domain entity → DTO</text>
+
+  <!-- Arrow -->
+  <text x="520" y="322" text-anchor="middle" class="arrow">&#8595; &#8593;</text>
+  <text x="580" y="320" class="arrow-label">IMediator.Send(command/query)</text>
+
+  <!-- ==================== MEDIATR PIPELINE ==================== -->
+  <rect x="40" y="332" width="1020" height="90" rx="8" fill="#f6f2ff" stroke="#a56eff" stroke-width="2"/>
+  <rect x="50" y="320" width="280" height="14" fill="#f6f2ff"/>
+  <text x="55" y="330" class="layer-label" fill="#a56eff">MEDIATR PIPELINE — BEHAVIORS (ORDERED)</text>
+  <!-- Tracing -->
+  <rect x="55" y="346" width="235" height="56" rx="5" fill="white" stroke="#a56eff" stroke-width="1.5"/>
+  <text x="65" y="362" class="box-title" fill="#a56eff">1. TracingBehavior</text>
+  <text x="65" y="376" class="box-code">ActivitySource: App.MediatR</text>
+  <text x="65" y="390" class="box-desc">OpenTelemetry span per request</text>
+  <!-- Logging -->
+  <rect x="300" y="346" width="235" height="56" rx="5" fill="white" stroke="#a56eff" stroke-width="1.5"/>
+  <text x="310" y="362" class="box-title" fill="#a56eff">2. LoggingBehavior</text>
+  <text x="310" y="376" class="box-code">Serilog {@Request}, elapsed ms</text>
+  <text x="310" y="390" class="box-desc">Structured logging with Stopwatch</text>
+  <!-- Transaction -->
+  <rect x="545" y="346" width="245" height="56" rx="5" fill="white" stroke="#a56eff" stroke-width="1.5"/>
+  <text x="555" y="362" class="box-title" fill="#a56eff">3. TransactionBehavior</text>
+  <text x="555" y="376" class="box-code">IUnitOfWork (ICommand only)</text>
+  <text x="555" y="390" class="box-desc">EF transaction; commit/rollback</text>
+  <!-- Exception -->
+  <rect x="800" y="346" width="245" height="56" rx="5" fill="white" stroke="#a56eff" stroke-width="1.5"/>
+  <text x="810" y="362" class="box-title" fill="#a56eff">4. ExceptionHandlingBehavior</text>
+  <text x="810" y="376" class="box-code">DB / SQL / Timeout exceptions</text>
+  <text x="810" y="390" class="box-desc">Transforms → Result.Conflict/Error</text>
+
+  <!-- Arrow -->
+  <text x="520" y="442" text-anchor="middle" class="arrow">&#8595; &#8593;</text>
+  <text x="580" y="440" class="arrow-label">Result&lt;T&gt;</text>
+
+  <!-- ==================== USECASES ==================== -->
+  <rect x="40" y="452" width="1020" height="80" rx="8" fill="#defbe6" stroke="#0e6027" stroke-width="2"/>
+  <rect x="50" y="440" width="285" height="14" fill="#defbe6"/>
+  <text x="55" y="450" class="layer-label" fill="#0e6027">SERVER.USECASES — APPLICATION (CQRS)</text>
+  <!-- Commands -->
+  <rect x="55" y="465" width="310" height="52" rx="5" fill="white" stroke="#0e6027" stroke-width="1.5"/>
+  <text x="65" y="481" class="box-title" fill="#0e6027">Commands (Mutations)</text>
+  <text x="65" y="495" class="box-code">ICommand&lt;T&gt; + ICommandHandler</text>
+  <text x="65" y="509" class="box-desc">Create, update, delete operations</text>
+  <!-- Queries -->
+  <rect x="380" y="465" width="310" height="52" rx="5" fill="white" stroke="#0e6027" stroke-width="1.5"/>
+  <text x="390" y="481" class="box-title" fill="#0e6027">Queries (Reads)</text>
+  <text x="390" y="495" class="box-code">IQuery&lt;T&gt; + IQueryHandler</text>
+  <text x="390" y="509" class="box-desc">Get, list, search with Specifications</text>
+  <!-- Interfaces -->
+  <rect x="705" y="465" width="340" height="52" rx="5" fill="white" stroke="#0e6027" stroke-width="1.5"/>
+  <text x="715" y="481" class="box-title" fill="#0e6027">Interfaces</text>
+  <text x="715" y="495" class="box-code">IUserContext, IEmailSender, etc.</text>
+  <text x="715" y="509" class="box-desc">Port definitions for infrastructure</text>
+
+  <!-- Arrow -->
+  <text x="520" y="552" text-anchor="middle" class="arrow">&#8595;</text>
+  <text x="545" y="550" class="arrow-label">uses domain entities &amp; specifications</text>
+
+  <!-- ==================== CORE ==================== -->
+  <rect x="40" y="562" width="1020" height="80" rx="8" fill="#fff8e1" stroke="#b28600" stroke-width="2"/>
+  <rect x="50" y="550" width="180" height="14" fill="#fff8e1"/>
+  <text x="55" y="560" class="layer-label" fill="#b28600">SERVER.CORE — DOMAIN</text>
+  <!-- Aggregates -->
+  <rect x="55" y="575" width="235" height="52" rx="5" fill="white" stroke="#b28600" stroke-width="1.5"/>
+  <text x="65" y="591" class="box-title" fill="#b28600">Aggregate Roots</text>
+  <text x="65" y="605" class="box-code">Article, Author, Tag, User</text>
+  <text x="65" y="619" class="box-desc">Each in {Name}Aggregate namespace</text>
+  <!-- Child Entities -->
+  <rect x="300" y="575" width="220" height="52" rx="5" fill="white" stroke="#b28600" stroke-width="1.5"/>
+  <text x="310" y="591" class="box-title" fill="#b28600">Child Entities</text>
+  <text x="310" y="605" class="box-code">Comment, UserFollowing</text>
+  <text x="310" y="619" class="box-desc">Owned by aggregate roots</text>
+  <!-- Specifications -->
+  <rect x="530" y="575" width="235" height="52" rx="5" fill="white" stroke="#b28600" stroke-width="1.5"/>
+  <text x="540" y="591" class="box-title" fill="#b28600">Specifications</text>
+  <text x="540" y="605" class="box-code">ArticleBySlugSpec, etc.</text>
+  <text x="540" y="619" class="box-desc">Ardalis.Specification query objects</text>
+  <!-- Domain Events -->
+  <rect x="775" y="575" width="270" height="52" rx="5" fill="white" stroke="#b28600" stroke-width="1.5"/>
+  <text x="785" y="591" class="box-title" fill="#b28600">Domain Events</text>
+  <text x="785" y="605" class="box-code">IDomainEvent : INotification</text>
+  <text x="785" y="619" class="box-desc">Collected in EntityBase, published post-commit</text>
+
+  <!-- Arrow -->
+  <text x="520" y="662" text-anchor="middle" class="arrow">&#8595;</text>
+  <text x="545" y="660" class="arrow-label">extends EntityBase, IAggregateRoot</text>
+
+  <!-- ==================== SHARED KERNEL ==================== -->
+  <rect x="40" y="672" width="1020" height="85" rx="8" fill="#f4f4f4" stroke="#6c757d" stroke-width="2"/>
+  <rect x="50" y="660" width="305" height="14" fill="#f4f4f4"/>
+  <text x="55" y="670" class="layer-label" fill="#6c757d">SERVER.SHAREDKERNEL — CONTRACTS &amp; ABSTRACTIONS</text>
+  <!-- Result -->
+  <rect x="55" y="688" width="235" height="56" rx="5" fill="white" stroke="#6c757d" stroke-width="1.5"/>
+  <text x="65" y="704" class="box-title" fill="#6c757d">Result&lt;T&gt;</text>
+  <text x="65" y="718" class="box-code">Success | Created | Invalid | NotFound | ...</text>
+  <text x="65" y="732" class="box-desc">Replace exceptions for control flow</text>
+  <!-- IRepository -->
+  <rect x="300" y="688" width="225" height="56" rx="5" fill="white" stroke="#6c757d" stroke-width="1.5"/>
+  <text x="310" y="704" class="box-title" fill="#6c757d">IRepository&lt;T&gt;</text>
+  <text x="310" y="718" class="box-code">Add, Update, Delete, GetById, List</text>
+  <text x="310" y="732" class="box-desc">Constrained to IAggregateRoot</text>
+  <!-- EntityBase -->
+  <rect x="535" y="688" width="240" height="56" rx="5" fill="white" stroke="#6c757d" stroke-width="1.5"/>
+  <text x="545" y="704" class="box-title" fill="#6c757d">EntityBase</text>
+  <text x="545" y="718" class="box-code">Id, ChangeCheck, Created/Updated At/By</text>
+  <text x="545" y="732" class="box-desc">Audit properties + concurrency token</text>
+  <!-- MediatR Contracts -->
+  <rect x="785" y="688" width="260" height="56" rx="5" fill="white" stroke="#6c757d" stroke-width="1.5"/>
+  <text x="795" y="704" class="box-title" fill="#6c757d">MediatR Contracts</text>
+  <text x="795" y="718" class="box-code">ICommand&lt;T&gt;, IQuery&lt;T&gt;</text>
+  <text x="795" y="732" class="box-desc">Request hierarchy for CQRS</text>
+
+  <!-- Arrow -->
+  <text x="520" y="777" text-anchor="middle" class="arrow">&#8595;</text>
+  <text x="545" y="775" class="arrow-label">implemented by</text>
+
+  <!-- ==================== INFRASTRUCTURE ==================== -->
+  <rect x="40" y="787" width="1020" height="90" rx="8" fill="#fff0f7" stroke="#d02670" stroke-width="2"/>
+  <rect x="50" y="775" width="270" height="14" fill="#fff0f7"/>
+  <text x="55" y="785" class="layer-label" fill="#d02670">SERVER.INFRASTRUCTURE — DATA &amp; SERVICES</text>
+  <!-- EfRepository -->
+  <rect x="55" y="800" width="185" height="62" rx="5" fill="white" stroke="#d02670" stroke-width="1.5"/>
+  <text x="65" y="816" class="box-title" fill="#d02670">EfRepository&lt;T&gt;</text>
+  <text x="65" y="830" class="box-code">Ardalis RepositoryBase&lt;T&gt;</text>
+  <text x="65" y="844" class="box-desc">Implements IRepository via EF Core</text>
+  <!-- AppDbContext -->
+  <rect x="250" y="800" width="200" height="62" rx="5" fill="white" stroke="#d02670" stroke-width="1.5"/>
+  <text x="260" y="816" class="box-title" fill="#d02670">AppDbContext</text>
+  <text x="260" y="830" class="box-code">MultiTenantIdentityDbContext</text>
+  <text x="260" y="844" class="box-desc">Audit.NET, domain event dispatch</text>
+  <!-- UnitOfWork -->
+  <rect x="460" y="800" width="190" height="62" rx="5" fill="white" stroke="#d02670" stroke-width="1.5"/>
+  <text x="470" y="816" class="box-title" fill="#d02670">UnitOfWork</text>
+  <text x="470" y="830" class="box-code">ExecuteInTransactionAsync()</text>
+  <text x="470" y="844" class="box-desc">EF execution strategy + audit scope</text>
+  <!-- Services -->
+  <rect x="660" y="800" width="180" height="62" rx="5" fill="white" stroke="#d02670" stroke-width="1.5"/>
+  <text x="670" y="816" class="box-title" fill="#d02670">Services</text>
+  <text x="670" y="830" class="box-code">UserContext, BcryptHasher</text>
+  <text x="670" y="844" class="box-desc">Infrastructure implementations</text>
+  <!-- Domain Event Dispatcher -->
+  <rect x="850" y="800" width="195" height="62" rx="5" fill="white" stroke="#d02670" stroke-width="1.5"/>
+  <text x="860" y="816" class="box-title" fill="#d02670">Event Dispatcher</text>
+  <text x="860" y="830" class="box-code">MediatRDomainEventDispatcher</text>
+  <text x="860" y="844" class="box-desc">Publishes via mediator.Publish()</text>
+
+  <!-- Arrow -->
+  <text x="520" y="897" text-anchor="middle" class="arrow">&#8595;</text>
+  <text x="545" y="895" class="arrow-label">persists to</text>
+
+  <!-- ==================== EXTERNAL ==================== -->
+  <rect x="40" y="907" width="1020" height="75" rx="8" fill="#e8e8e8" stroke="#343a3f" stroke-width="2"/>
+  <rect x="50" y="895" width="130" height="14" fill="#e8e8e8"/>
+  <text x="55" y="905" class="layer-label" fill="#343a3f">EXTERNAL SYSTEMS</text>
+  <!-- SQL Server -->
+  <rect x="55" y="920" width="235" height="48" rx="5" fill="#21272a" stroke="#343a3f" stroke-width="1.5"/>
+  <text x="65" y="936" class="box-title" fill="#78a9ff">SQL Server</text>
+  <text x="65" y="950" style="font-size:10px; fill:#a8a8a8; font-family:monospace;">Multi-tenant (Finbuckle)</text>
+  <text x="65" y="962" style="font-size:10px; fill:#6f6f6f; font-style:italic;">Query filters per tenant ID</text>
+  <!-- Audit.NET -->
+  <rect x="300" y="920" width="220" height="48" rx="5" fill="#21272a" stroke="#343a3f" stroke-width="1.5"/>
+  <text x="310" y="936" class="box-title" fill="#78a9ff">Audit.NET</text>
+  <text x="310" y="950" style="font-size:10px; fill:#a8a8a8; font-family:monospace;">File-based audit logs</text>
+  <text x="310" y="962" style="font-size:10px; fill:#6f6f6f; font-style:italic;">Transaction-aware, correlation ID</text>
+  <!-- OpenTelemetry -->
+  <rect x="530" y="920" width="235" height="48" rx="5" fill="#21272a" stroke="#343a3f" stroke-width="1.5"/>
+  <text x="540" y="936" class="box-title" fill="#78a9ff">OpenTelemetry</text>
+  <text x="540" y="950" style="font-size:10px; fill:#a8a8a8; font-family:monospace;">Jaeger · Prometheus · Seq</text>
+  <text x="540" y="962" style="font-size:10px; fill:#6f6f6f; font-style:italic;">Traces, metrics, structured logs</text>
+  <!-- Azure -->
+  <rect x="775" y="920" width="270" height="48" rx="5" fill="#21272a" stroke="#343a3f" stroke-width="1.5"/>
+  <text x="785" y="936" class="box-title" fill="#78a9ff">Azure</text>
+  <text x="785" y="950" style="font-size:10px; fill:#a8a8a8; font-family:monospace;">App Config · Monitor · App Service</text>
+  <text x="785" y="962" style="font-size:10px; fill:#6f6f6f; font-style:italic;">Feature flags, production telemetry</text>
+
+  <!-- ==================== LEGEND ==================== -->
+  <line x1="40" y1="1005" x2="1060" y2="1005" stroke="#e0e0e0" stroke-width="1"/>
+  <!-- Web -->
+  <rect x="40" y="1015" width="12" height="12" rx="2" fill="#edf5ff" stroke="#4589ff" stroke-width="1.5"/>
+  <text x="58" y="1025" class="legend-text">Presentation (Web)</text>
+  <!-- MediatR -->
+  <rect x="180" y="1015" width="12" height="12" rx="2" fill="#f6f2ff" stroke="#a56eff" stroke-width="1.5"/>
+  <text x="198" y="1025" class="legend-text">Pipeline (MediatR)</text>
+  <!-- UseCases -->
+  <rect x="330" y="1015" width="12" height="12" rx="2" fill="#defbe6" stroke="#0e6027" stroke-width="1.5"/>
+  <text x="348" y="1025" class="legend-text">Application (UseCases)</text>
+  <!-- Core -->
+  <rect x="500" y="1015" width="12" height="12" rx="2" fill="#fff8e1" stroke="#b28600" stroke-width="1.5"/>
+  <text x="518" y="1025" class="legend-text">Domain (Core)</text>
+  <!-- SharedKernel -->
+  <rect x="620" y="1015" width="12" height="12" rx="2" fill="#f4f4f4" stroke="#6c757d" stroke-width="1.5"/>
+  <text x="638" y="1025" class="legend-text">Contracts (SharedKernel)</text>
+  <!-- Infrastructure -->
+  <rect x="790" y="1015" width="12" height="12" rx="2" fill="#fff0f7" stroke="#d02670" stroke-width="1.5"/>
+  <text x="808" y="1025" class="legend-text">Infrastructure</text>
+  <!-- External -->
+  <rect x="910" y="1015" width="12" height="12" rx="2" fill="#e8e8e8" stroke="#343a3f" stroke-width="1.5"/>
+  <text x="928" y="1025" class="legend-text">External Systems</text>
+
+  <!-- ==================== RESULT TABLE ==================== -->
+  <text x="40" y="1065" style="font-size:16px; font-weight:600; fill:#161616;">Result&lt;T&gt; → HTTP Status Mapping</text>
+
+  <!-- Table header -->
+  <text x="40" y="1090" class="table-header">RESULT STATUS</text>
+  <text x="220" y="1090" class="table-header">HTTP CODE</text>
+  <text x="400" y="1090" class="table-header">WHEN</text>
+  <line x1="40" y1="1096" x2="700" y2="1096" stroke="#e0e0e0" stroke-width="2"/>
+
+  <!-- Table rows -->
+  <text x="40" y="1116" class="table-cell">Success</text>
+  <text x="220" y="1116" class="table-cell http-2xx">200 OK</text>
+  <text x="400" y="1116" class="table-cell">Successful read or update</text>
+  <line x1="40" y1="1122" x2="700" y2="1122" stroke="#f0f0f0" stroke-width="1"/>
+
+  <text x="40" y="1140" class="table-cell">Created</text>
+  <text x="220" y="1140" class="table-cell http-2xx">201 Created</text>
+  <text x="400" y="1140" class="table-cell">New resource created</text>
+  <line x1="40" y1="1146" x2="700" y2="1146" stroke="#f0f0f0" stroke-width="1"/>
+
+  <text x="40" y="1164" class="table-cell">NoContent</text>
+  <text x="220" y="1164" class="table-cell http-2xx">204 No Content</text>
+  <text x="400" y="1164" class="table-cell">Delete or void operation</text>
+  <line x1="40" y1="1170" x2="700" y2="1170" stroke="#f0f0f0" stroke-width="1"/>
+
+  <text x="40" y="1188" class="table-cell">Invalid</text>
+  <text x="220" y="1188" class="table-cell http-4xx">400 Bad Request</text>
+  <text x="400" y="1188" class="table-cell">Business rule validation failure</text>
+  <line x1="40" y1="1194" x2="700" y2="1194" stroke="#f0f0f0" stroke-width="1"/>
+
+  <text x="40" y="1212" class="table-cell">Unauthorized</text>
+  <text x="220" y="1212" class="table-cell http-4xx">401 Unauthorized</text>
+  <text x="400" y="1212" class="table-cell">Missing or invalid credentials</text>
+  <line x1="40" y1="1218" x2="700" y2="1218" stroke="#f0f0f0" stroke-width="1"/>
+
+  <text x="40" y="1236" class="table-cell">Forbidden</text>
+  <text x="220" y="1236" class="table-cell http-4xx">403 Forbidden</text>
+  <text x="400" y="1236" class="table-cell">Authenticated but not authorized</text>
+  <line x1="40" y1="1242" x2="700" y2="1242" stroke="#f0f0f0" stroke-width="1"/>
+
+  <text x="40" y="1260" class="table-cell">NotFound</text>
+  <text x="220" y="1260" class="table-cell http-4xx">404 Not Found</text>
+  <text x="400" y="1260" class="table-cell">Entity doesn't exist</text>
+  <line x1="40" y1="1266" x2="700" y2="1266" stroke="#f0f0f0" stroke-width="1"/>
+
+  <text x="40" y="1284" class="table-cell">Conflict</text>
+  <text x="220" y="1284" class="table-cell http-4xx">409 Conflict</text>
+  <text x="400" y="1284" class="table-cell">Concurrency or duplicate key</text>
+  <line x1="40" y1="1290" x2="700" y2="1290" stroke="#f0f0f0" stroke-width="1"/>
+
+  <text x="40" y="1308" class="table-cell">Error</text>
+  <text x="220" y="1308" class="table-cell http-4xx">422 Unprocessable</text>
+  <text x="400" y="1308" class="table-cell">Semantic error in request</text>
+  <line x1="40" y1="1314" x2="700" y2="1314" stroke="#f0f0f0" stroke-width="1"/>
+
+  <text x="40" y="1332" class="table-cell">CriticalError</text>
+  <text x="220" y="1332" class="table-cell http-5xx">500 Internal</text>
+  <text x="400" y="1332" class="table-cell">Unhandled exception</text>
+  <line x1="40" y1="1338" x2="700" y2="1338" stroke="#f0f0f0" stroke-width="1"/>
+
+  <text x="40" y="1356" class="table-cell">Unavailable</text>
+  <text x="220" y="1356" class="table-cell http-5xx">503 Unavailable</text>
+  <text x="400" y="1356" class="table-cell">Timeout or transient failure</text>
+
+  <!-- ==================== NOTE ==================== -->
+  <rect x="40" y="1380" width="1020" height="40" rx="4" fill="#f4f4f4" stroke="none"/>
+  <line x1="40" y1="1380" x2="40" y2="1420" stroke="#8d8d8d" stroke-width="3"/>
+  <text x="55" y="1396" class="note-bold">Dependency Rule:</text>
+  <text x="165" y="1396" class="note">Inner layers (SharedKernel, Core) have zero knowledge of outer layers. UseCases depends on Core + SharedKernel.</text>
+  <text x="55" y="1412" class="note">Infrastructure implements SharedKernel interfaces. Web depends on everything but is the composition root. Enforced by project references and 35+ Roslyn analyzers.</text>
+
+  <!-- Sidebar annotation -->
+  <text x="1075" y="550" transform="rotate(90, 1075, 550)" style="font-size:10px; fill:#a8a8a8; font-weight:600; text-transform:uppercase; letter-spacing:2px;">Dependencies point inward</text>
+</svg>

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Server.Analyzers         — 32 custom Roslyn analyzers (SRV + PV series)
 
 Endpoints are thin: bind request -> authorize -> delegate to MediatR -> map response. Business rules live in handlers. Persistence is abstracted behind repository interfaces.
 
+![Backend Architecture Diagram](Docs/architecture-diagram.svg)
+
 **Cross-cutting concerns:**
 - **Serilog** — structured logging with enrichers, file sinks, and Seq integration
 - **Audit.NET** — automatic audit trails for EF Core entity changes and Identity operations


### PR DESCRIPTION
## Summary
- Adds an SVG architecture diagram that renders inline in the README, showing the request pipeline through all Clean Architecture layers
- Also includes an interactive HTML version for detailed exploration

## Test plan
- [ ] Verify SVG renders correctly in README on GitHub
- [ ] Verify HTML version opens and displays correctly in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)