### PR TITLE
docs: fix architecture diagram dark mode background

### DIFF
--- a/Docs/architecture-diagram.svg
+++ b/Docs/architecture-diagram.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 1580" font-family="'Segoe UI', system-ui, -apple-system, sans-serif">
+  <rect width="1100" height="1580" fill="white"/>
   <style>
     .layer-label { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 1.2px; }
     .box-title { font-size: 12px; font-weight: 600; }


### PR DESCRIPTION
## Summary
- Adds a white background rectangle to the architecture SVG so it renders correctly in GitHub dark mode.

## Test plan
- [ ] Verify the SVG renders with a white background when viewing the repo in dark mode on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)