### PR TITLE
lint: enable Carbon motion stylelint rules

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -52,6 +52,7 @@ The generated API client (`src/api/generated/`) is the **type contract** between
 - **Colors:** Use `var(--cds-text-primary)`, `var(--cds-layer-01)`, etc. These ARE real CSS custom properties emitted by Carbon's theme system.
 - **Typography:** `@use '@carbon/react/scss/type' as type;` then use `@include type.type-style('heading-03');`. SCSS mixins only — sets font-size, weight, line-height, letter-spacing together. Never set font-size/font-weight individually.
 - **Font:** IBM Plex Sans globally (from Carbon). No custom fonts.
+- **Philosophy:** Express all visual decisions through Carbon tokens and mixins, not raw CSS values. Tokens are the API contract; raw values bypass the design system.
 - **Never use hard-coded hex colors, arbitrary rem/px spacing, or arbitrary font-size values.** `stylelint-plugin-carbon-tokens` enforces all three (`carbon/theme-use`, `carbon/layout-use`, `carbon/type-use`) via `LintClientStylelintVerify`.
 
 **Never write direct CSS overrides for Carbon components.** Before adding custom CSS for colors, theming, hover states, or layout of any Carbon component:

--- a/App/Client/.stylelintrc.json
+++ b/App/Client/.stylelintrc.json
@@ -34,6 +34,22 @@
         "severity": "error"
       }
     ],
+    "carbon/motion-duration-use": [
+      true,
+      {
+        "acceptCarbonCustomProp": true,
+        "acceptValues": [
+          "/^0$/"
+        ],
+        "severity": "error"
+      }
+    ],
+    "carbon/motion-easing-use": [
+      true,
+      {
+        "severity": "error"
+      }
+    ],
     "carbon/type-use": [
       true,
       {


### PR DESCRIPTION
## Summary
- Enable `carbon/motion-duration-use` and `carbon/motion-easing-use` in `.stylelintrc.json` — we were using 3 of 5 rules from `stylelint-plugin-carbon-tokens`, now all 5 are active
- Add Carbon's token-first philosophy statement to `.claude/rules/frontend.md`

## Test plan
- [x] `LintClientStylelintVerify` passes (no existing motion violations)
- [x] `LintClaudeRulesVerify` passes (frontend.md at 78/85 lines)
- [x] Pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)