### PR TITLE
feat: add ESLint guardrails and tighten stylelint Carbon token enforcement

### DIFF
--- a/App/Client/.stylelintrc.json
+++ b/App/Client/.stylelintrc.json
@@ -15,8 +15,6 @@
         "acceptValues": [
           "/inherit|initial|none|unset/",
           "/currentColor|transparent/",
-          "white",
-          "/rgb\\(/",
           "/^0$/"
         ],
         "severity": "error"

--- a/App/Client/eslint.config.js
+++ b/App/Client/eslint.config.js
@@ -4,6 +4,7 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import i18next from 'eslint-plugin-i18next'
 import tseslint from 'typescript-eslint'
+import simpleImportSort from 'eslint-plugin-simple-import-sort'
 import { defineConfig, globalIgnores } from 'eslint/config'
 import customRules from './eslint-plugin-custom-rules/index.js'
 
@@ -20,6 +21,20 @@ export default defineConfig([
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+    },
+  },
+  {
+    files: ['**/*.{ts,tsx}'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+    },
+  },
+  {
+    files: ['**/*.{ts,tsx}'],
+    plugins: { 'simple-import-sort': simpleImportSort },
+    rules: {
+      'simple-import-sort/imports': 'error',
+      'simple-import-sort/exports': 'error',
     },
   },
   {

--- a/App/Client/package-lock.json
+++ b/App/Client/package-lock.json
@@ -33,6 +33,7 @@
         "eslint-plugin-i18next": "^6.1.3",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
+        "eslint-plugin-simple-import-sort": "^13.0.0",
         "globals": "^16.4.0",
         "jsdom": "^27.0.0",
         "mkdirp": "^3.0.1",
@@ -4103,6 +4104,16 @@
       "license": "MIT",
       "peerDependencies": {
         "eslint": ">=8.40"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-13.0.0.tgz",
+      "integrity": "sha512-McAc+/Nlvcg4byY/CABGH8kqnefWBj8s3JA2okEtz8ixbECQgU46p0HkTUKa4YS7wvgGceimlc34p1nXqbWqtA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/App/Client/package.json
+++ b/App/Client/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-i18next": "^6.1.3",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
+    "eslint-plugin-simple-import-sort": "^13.0.0",
     "globals": "^16.4.0",
     "jsdom": "^27.0.0",
     "mkdirp": "^3.0.1",

--- a/App/Client/src/App.test.tsx
+++ b/App/Client/src/App.test.tsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
-import App from './App'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
 import { articlesApi } from './api/articles'
-import { tagsApi } from './api/tags'
 import { authApi } from './api/auth'
+import { tagsApi } from './api/tags'
+import App from './App'
 
 vi.mock('./api/articles', () => ({
   articlesApi: {

--- a/App/Client/src/App.tsx
+++ b/App/Client/src/App.tsx
@@ -1,13 +1,14 @@
-import { BrowserRouter, Routes, Route } from 'react-router';
-import { lazy, Suspense } from 'react';
 import { Content, Loading } from '@carbon/react';
+import { lazy, Suspense } from 'react';
+import { BrowserRouter, Route,Routes } from 'react-router';
+
+import { AppHeader } from './components/AppHeader';
+import { ProtectedRoute } from './components/ProtectedRoute';
+import { RoleProtectedRoute } from './components/RoleProtectedRoute';
+import { ToastContainer } from './components/ToastContainer';
 import { AuthProvider } from './context/AuthContext';
 import { FeatureFlagProvider } from './context/FeatureFlagContext';
 import { ToastProvider } from './context/ToastContext';
-import { AppHeader } from './components/AppHeader';
-import { ToastContainer } from './components/ToastContainer';
-import { ProtectedRoute } from './components/ProtectedRoute';
-import { RoleProtectedRoute } from './components/RoleProtectedRoute';
 
 const HomePage = lazy(() => import('./pages/HomePage').then(m => ({ default: m.HomePage })));
 const LoginPage = lazy(() => import('./pages/LoginPage').then(m => ({ default: m.LoginPage })));

--- a/App/Client/src/api/articles.test.ts
+++ b/App/Client/src/api/articles.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach,describe, expect, it, vi } from 'vitest';
+
 import { articlesApi } from './articles';
 import { getApiClient } from './clientFactory';
 

--- a/App/Client/src/api/articles.ts
+++ b/App/Client/src/api/articles.ts
@@ -1,12 +1,12 @@
-import { getApiClient } from './clientFactory';
-import { convertKiotaError } from './errors';
 import type {
   ArticleResponse,
   ArticlesResponse,
   CreateArticleRequest,
-  UpdateArticleRequest,
   ListArticlesRequest,
+  UpdateArticleRequest,
 } from '../types/article';
+import { getApiClient } from './clientFactory';
+import { convertKiotaError } from './errors';
 
 export const articlesApi = {
   listArticles: async (params: ListArticlesRequest = {}): Promise<ArticlesResponse> => {

--- a/App/Client/src/api/auth.ts
+++ b/App/Client/src/api/auth.ts
@@ -1,6 +1,6 @@
+import type { UserResponse } from '../types/user';
 import { getApiClient } from './clientFactory';
 import { convertKiotaError } from './errors';
-import type { UserResponse } from '../types/user';
 
 export const authApi = {
   login: async (email: string, password: string): Promise<void> => {

--- a/App/Client/src/api/client.test.ts
+++ b/App/Client/src/api/client.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect,it } from 'vitest';
+
 import { ApiError } from './client';
 
 describe('ApiError', () => {

--- a/App/Client/src/api/clientFactory.ts
+++ b/App/Client/src/api/clientFactory.ts
@@ -3,9 +3,10 @@ import {
   FetchRequestAdapter,
   HttpClient,
 } from '@microsoft/kiota-http-fetchlibrary';
+
 import {
-  createConduitApiClient,
   type ConduitApiClient,
+  createConduitApiClient,
 } from './generated/conduitApiClient.js';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || '';

--- a/App/Client/src/api/comments.test.ts
+++ b/App/Client/src/api/comments.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { commentsApi } from './comments';
+import { beforeEach,describe, expect, it, vi } from 'vitest';
+
 import { getApiClient } from './clientFactory';
+import { commentsApi } from './comments';
 
 vi.mock('./clientFactory');
 

--- a/App/Client/src/api/comments.ts
+++ b/App/Client/src/api/comments.ts
@@ -1,9 +1,9 @@
-import { getApiClient } from './clientFactory';
-import { convertKiotaError } from './errors';
 import type {
   CommentResponse,
   CommentsResponse,
 } from '../types/comment';
+import { getApiClient } from './clientFactory';
+import { convertKiotaError } from './errors';
 
 export const commentsApi = {
   getComments: async (slug: string): Promise<CommentsResponse> => {

--- a/App/Client/src/api/profiles.test.ts
+++ b/App/Client/src/api/profiles.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { profilesApi } from './profiles';
+import { beforeEach,describe, expect, it, vi } from 'vitest';
+
 import { getApiClient } from './clientFactory';
+import { profilesApi } from './profiles';
 
 vi.mock('./clientFactory');
 

--- a/App/Client/src/api/profiles.ts
+++ b/App/Client/src/api/profiles.ts
@@ -1,6 +1,6 @@
+import type { ProfileResponse } from '../types/profile';
 import { getApiClient } from './clientFactory';
 import { convertKiotaError } from './errors';
-import type { ProfileResponse } from '../types/profile';
 
 export const profilesApi = {
   getProfile: async (username: string): Promise<ProfileResponse> => {

--- a/App/Client/src/api/tags.test.ts
+++ b/App/Client/src/api/tags.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { tagsApi } from './tags';
+import { beforeEach,describe, expect, it, vi } from 'vitest';
+
 import { getApiClient } from './clientFactory';
+import { tagsApi } from './tags';
 
 vi.mock('./clientFactory');
 

--- a/App/Client/src/api/tags.ts
+++ b/App/Client/src/api/tags.ts
@@ -1,6 +1,6 @@
+import type { TagsResponse } from '../types/tag';
 import { getApiClient } from './clientFactory';
 import { convertKiotaError } from './errors';
-import type { TagsResponse } from '../types/tag';
 
 export const tagsApi = {
   getTags: async (): Promise<TagsResponse> => {

--- a/App/Client/src/components/AppHeader.test.tsx
+++ b/App/Client/src/components/AppHeader.test.tsx
@@ -1,10 +1,11 @@
-import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
-import { AppHeader } from './AppHeader';
+import { describe, expect, it, vi } from 'vitest';
+
 import { AuthContext } from '../context/AuthContext';
 import type { User } from '../types/user';
+import { AppHeader } from './AppHeader';
 
 const mockLogout = vi.fn();
 

--- a/App/Client/src/components/AppHeader.tsx
+++ b/App/Client/src/components/AppHeader.tsx
@@ -1,31 +1,32 @@
-import React, { useEffect, useRef } from 'react';
-import { Link, useLocation, useNavigate } from 'react-router';
+import './AppHeader.scss';
+
+import {
+  Edit,
+  Home,
+  Login,
+  Logout,
+  Settings,
+  UserAvatar,
+  UserFollow,
+  UserMultiple,
+} from '@carbon/icons-react';
 import {
   Header,
   HeaderContainer,
   HeaderMenuButton,
   HeaderName,
-  SkipToContent,
-  Theme,
   SideNav,
   SideNavItems,
   SideNavLink,
+  SkipToContent,
+  Theme,
 } from '@carbon/react';
-import {
-  Home,
-  Edit,
-  UserMultiple,
-  Settings,
-  UserAvatar,
-  Login,
-  UserFollow,
-  Logout,
-} from '@carbon/icons-react';
+import React, { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link, useLocation, useNavigate } from 'react-router';
+
 import { useAuth } from '../hooks/useAuth';
 import { RequireRole } from './RequireRole';
-
-import './AppHeader.scss';
 
 export const AppHeader: React.FC = () => {
   const { t } = useTranslation();

--- a/App/Client/src/components/ArticleList.test.tsx
+++ b/App/Client/src/components/ArticleList.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-import { ArticleList } from './ArticleList';
+import { describe, expect, it, vi } from 'vitest';
+
 import { AuthContext } from '../context/AuthContext';
+import { ArticleList } from './ArticleList';
 
 const mockArticles = [
   {

--- a/App/Client/src/components/ArticleList.tsx
+++ b/App/Client/src/components/ArticleList.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
-import { Loading } from '@carbon/react';
-import { useTranslation } from 'react-i18next';
-import { ArticlePreview } from './ArticlePreview';
-import type { Article } from '../types/article';
 import './ArticleList.scss';
+
+import { Loading } from '@carbon/react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { Article } from '../types/article';
+import { ArticlePreview } from './ArticlePreview';
 
 interface ArticleListProps {
   articles: Article[];

--- a/App/Client/src/components/ArticlePreview.scss
+++ b/App/Client/src/components/ArticlePreview.scss
@@ -51,7 +51,7 @@
 
 .favorite-button.favorited {
   background-color: var(--cds-link-primary);
-  color: white;
+  color: var(--cds-text-on-color);
 }
 
 .article-link {

--- a/App/Client/src/components/ArticlePreview.test.tsx
+++ b/App/Client/src/components/ArticlePreview.test.tsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-import { ArticlePreview } from './ArticlePreview';
-import { AuthContext } from '../context/AuthContext';
+import { describe, expect, it, vi } from 'vitest';
+
 import { DEFAULT_PROFILE_IMAGE } from '../constants';
+import { AuthContext } from '../context/AuthContext';
+import { ArticlePreview } from './ArticlePreview';
 
 const mockArticle = {
   slug: 'test-article',

--- a/App/Client/src/components/ArticlePreview.tsx
+++ b/App/Client/src/components/ArticlePreview.tsx
@@ -1,12 +1,13 @@
-import React from 'react';
-import { Link } from 'react-router';
-import { Tag, Button } from '@carbon/react';
-import { FavoriteFilled, Favorite } from '@carbon/icons-react';
-import { useTranslation } from 'react-i18next';
-import type { Article } from '../types/article';
-import { DEFAULT_PROFILE_IMAGE } from '../constants';
-
 import './ArticlePreview.scss';
+
+import { Favorite,FavoriteFilled } from '@carbon/icons-react';
+import { Button,Tag } from '@carbon/react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+import { DEFAULT_PROFILE_IMAGE } from '../constants';
+import type { Article } from '../types/article';
 
 interface ArticlePreviewProps {
   article: Article;

--- a/App/Client/src/components/ErrorDisplay.test.tsx
+++ b/App/Client/src/components/ErrorDisplay.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
-import { ErrorDisplay } from './ErrorDisplay';
-import { AppError } from '../utils/errors';
+import { beforeEach,describe, expect, it, vi } from 'vitest';
+
 import { ApiError } from '../api/client';
+import { AppError } from '../utils/errors';
+import { ErrorDisplay } from './ErrorDisplay';
 
 const mockShowToast = vi.fn().mockReturnValue('toast-id');
 const mockRemoveToast = vi.fn();

--- a/App/Client/src/components/ErrorDisplay.tsx
+++ b/App/Client/src/components/ErrorDisplay.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
-import { type AppError, normalizeError } from '../utils/errors';
+
 import { useToast } from '../hooks/useToast';
+import { type AppError, normalizeError } from '../utils/errors';
 
 export interface ErrorDisplayProps {
   error: AppError | unknown | null;

--- a/App/Client/src/components/PageShell.test.tsx
+++ b/App/Client/src/components/PageShell.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { describe, expect,it } from 'vitest';
+
 import { PageShell } from './PageShell';
 
 describe('PageShell', () => {

--- a/App/Client/src/components/PageShell.tsx
+++ b/App/Client/src/components/PageShell.tsx
@@ -1,5 +1,5 @@
+import { Column,Grid } from '@carbon/react';
 import React from 'react';
-import { Grid, Column } from '@carbon/react';
 
 type ColumnLayout = 'narrow' | 'wide' | 'full' | 'two-column';
 

--- a/App/Client/src/components/ProtectedRoute.test.tsx
+++ b/App/Client/src/components/ProtectedRoute.test.tsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import { BrowserRouter, Route, Routes } from 'react-router'
-import { ProtectedRoute } from './ProtectedRoute'
-import { AuthProvider } from '../context/AuthContext'
+import { beforeEach,describe, expect, it, vi } from 'vitest'
+
 import { authApi } from '../api/auth'
+import { AuthProvider } from '../context/AuthContext'
+import { ProtectedRoute } from './ProtectedRoute'
 
 vi.mock('../api/auth', () => ({
   authApi: {

--- a/App/Client/src/components/ProtectedRoute.tsx
+++ b/App/Client/src/components/ProtectedRoute.tsx
@@ -1,7 +1,8 @@
+import { Loading } from '@carbon/react';
 import React from 'react';
 import { Navigate } from 'react-router';
+
 import { useAuth } from '../hooks/useAuth';
-import { Loading } from '@carbon/react';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;

--- a/App/Client/src/components/RequireRole.test.tsx
+++ b/App/Client/src/components/RequireRole.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { RequireRole } from './RequireRole';
+import { describe, expect, it, vi } from 'vitest';
+
 import { AuthContext } from '../context/AuthContextType';
 import type { User } from '../types/user';
+import { RequireRole } from './RequireRole';
 
 const renderWithAuth = (user: User | null, roles: string[], fallback?: React.ReactNode) => {
   return render(

--- a/App/Client/src/components/RequireRole.tsx
+++ b/App/Client/src/components/RequireRole.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { useHasRole } from '../hooks/useHasRole';
 
 interface RequireRoleProps {

--- a/App/Client/src/components/RoleProtectedRoute.test.tsx
+++ b/App/Client/src/components/RoleProtectedRoute.test.tsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router';
-import { RoleProtectedRoute } from './RoleProtectedRoute';
+import { MemoryRouter, Route,Routes } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { AuthContext } from '../context/AuthContextType';
 import type { User } from '../types/user';
+import { RoleProtectedRoute } from './RoleProtectedRoute';
 
 describe('RoleProtectedRoute', () => {
   const mockUser: User = {

--- a/App/Client/src/components/RoleProtectedRoute.tsx
+++ b/App/Client/src/components/RoleProtectedRoute.tsx
@@ -1,8 +1,9 @@
+import { Loading } from '@carbon/react';
 import React from 'react';
 import { Navigate } from 'react-router';
+
 import { useAuth } from '../hooks/useAuth';
 import { useHasRole } from '../hooks/useHasRole';
-import { Loading } from '@carbon/react';
 
 interface RoleProtectedRouteProps {
   children: React.ReactNode;

--- a/App/Client/src/components/TagList.test.tsx
+++ b/App/Client/src/components/TagList.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent,render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
 import { TagList } from './TagList';
 
 describe('TagList', () => {

--- a/App/Client/src/components/TagList.tsx
+++ b/App/Client/src/components/TagList.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import { OperationalTag, SkeletonText } from '@carbon/react';
-import { useTranslation } from 'react-i18next';
 import './TagList.scss';
+
+import { OperationalTag, SkeletonText } from '@carbon/react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface TagListProps {
   tags: string[];

--- a/App/Client/src/components/ToastContainer.tsx
+++ b/App/Client/src/components/ToastContainer.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
-import { ToastNotification } from '@carbon/react';
-import { useToast } from '../hooks/useToast';
 import './ToastContainer.scss';
+
+import { ToastNotification } from '@carbon/react';
+import React from 'react';
+
+import { useToast } from '../hooks/useToast';
 
 export const ToastContainer: React.FC = () => {
   const { toasts, removeToast } = useToast();

--- a/App/Client/src/context/AuthContext.test.tsx
+++ b/App/Client/src/context/AuthContext.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
-import { AuthProvider } from './AuthContext'
-import { useAuth } from '../hooks/useAuth'
+import { beforeEach,describe, expect, it, vi } from 'vitest'
+
 import { authApi } from '../api/auth'
+import { useAuth } from '../hooks/useAuth'
+import { AuthProvider } from './AuthContext'
 
 // Mock the auth API
 vi.mock('../api/auth', () => ({

--- a/App/Client/src/context/AuthContext.tsx
+++ b/App/Client/src/context/AuthContext.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect, type ReactNode } from 'react';
-import i18n from '../i18n/i18n';
+import React, { type ReactNode,useEffect, useState } from 'react';
+
 import { authApi } from '../api/auth';
 import { setApiLanguage } from '../api/clientFactory';
+import i18n from '../i18n/i18n';
 import type { User } from '../types/user';
 import { AuthContext } from './AuthContextType';
 

--- a/App/Client/src/context/AuthContextType.ts
+++ b/App/Client/src/context/AuthContextType.ts
@@ -1,4 +1,5 @@
 import { createContext } from 'react';
+
 import type { User } from '../types/user';
 
 export interface AuthContextType {

--- a/App/Client/src/context/FeatureFlagContext.tsx
+++ b/App/Client/src/context/FeatureFlagContext.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect, useCallback, useRef, type ReactNode } from 'react';
-import { FeatureManager, ConfigurationObjectFeatureFlagProvider } from '@microsoft/feature-management';
+import { ConfigurationObjectFeatureFlagProvider,FeatureManager } from '@microsoft/feature-management';
+import React, { type ReactNode,useCallback, useEffect, useRef, useState } from 'react';
+
 import { configApi } from '../api/configApi';
 import { featureFlagsApi } from '../api/featureFlagsApi';
 import { useAuth } from '../hooks/useAuth';

--- a/App/Client/src/context/ToastContext.tsx
+++ b/App/Client/src/context/ToastContext.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useCallback, type ReactNode } from 'react';
-import { ToastContext, type Toast } from './ToastContextType';
+import React, { type ReactNode,useCallback, useState } from 'react';
+
+import { type Toast,ToastContext } from './ToastContextType';
 
 export { ToastContext };
 

--- a/App/Client/src/hooks/useApiCall.test.ts
+++ b/App/Client/src/hooks/useApiCall.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
-import { useApiCall } from './useApiCall';
+import { act,renderHook } from '@testing-library/react';
+import { beforeEach,describe, expect, it, vi } from 'vitest';
+
 import { ApiError } from '../api/client';
+import { useApiCall } from './useApiCall';
 
 describe('useApiCall', () => {
   beforeEach(() => {

--- a/App/Client/src/hooks/useApiCall.ts
+++ b/App/Client/src/hooks/useApiCall.ts
@@ -1,4 +1,5 @@
-import { useState, useCallback, useRef } from 'react';
+import { useCallback, useRef,useState } from 'react';
+
 import { type AppError, normalizeError } from '../utils/errors';
 
 export interface UseApiCallResult<T> {

--- a/App/Client/src/hooks/useAuth.ts
+++ b/App/Client/src/hooks/useAuth.ts
@@ -1,4 +1,5 @@
 import { useContext } from 'react';
+
 import { AuthContext } from '../context/AuthContextType';
 
 export const useAuth = () => {

--- a/App/Client/src/hooks/useFeatureFlag.test.tsx
+++ b/App/Client/src/hooks/useFeatureFlag.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
 import { renderHook } from '@testing-library/react';
-import { useFeatureFlag } from './useFeatureFlag';
+import { describe, expect,it } from 'vitest';
+
 import { FeatureFlagContext } from '../context/FeatureFlagContextType';
+import { useFeatureFlag } from './useFeatureFlag';
 
 const wrapper =
   (flags: Record<string, boolean>) =>

--- a/App/Client/src/hooks/useFeatureFlag.ts
+++ b/App/Client/src/hooks/useFeatureFlag.ts
@@ -1,4 +1,5 @@
 import { useContext } from 'react';
+
 import { FeatureFlagContext } from '../context/FeatureFlagContextType';
 
 export const useFeatureFlag = (flagName: string): boolean => {

--- a/App/Client/src/hooks/useHasRole.test.tsx
+++ b/App/Client/src/hooks/useHasRole.test.tsx
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
-import { useHasRole } from './useHasRole';
+import { describe, expect, it, vi } from 'vitest';
+
 import { AuthContext } from '../context/AuthContextType';
 import type { User } from '../types/user';
+import { useHasRole } from './useHasRole';
 
 const wrapper = (user: User | null) => ({ children }: { children: React.ReactNode }) => (
   <AuthContext.Provider

--- a/App/Client/src/hooks/useRequireAuth.test.tsx
+++ b/App/Client/src/hooks/useRequireAuth.test.tsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { act,renderHook } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
-import { useRequireAuth } from './useRequireAuth';
-import { AuthContext } from '../context/AuthContextType';
+import { beforeEach,describe, expect, it, vi } from 'vitest';
+
 import { ApiError } from '../api/client';
+import { AuthContext } from '../context/AuthContextType';
+import { useRequireAuth } from './useRequireAuth';
 
 // Mock useNavigate
 const mockNavigate = vi.fn();

--- a/App/Client/src/hooks/useRequireAuth.ts
+++ b/App/Client/src/hooks/useRequireAuth.ts
@@ -1,7 +1,8 @@
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router';
-import { useAuth } from './useAuth';
+
 import { ApiError } from '../api/client';
+import { useAuth } from './useAuth';
 
 /**
  * A hook that provides a wrapper function for authenticated API actions.

--- a/App/Client/src/hooks/useToast.ts
+++ b/App/Client/src/hooks/useToast.ts
@@ -1,4 +1,5 @@
 import { useContext } from 'react';
+
 import { ToastContext } from '../context/ToastContextType';
 
 export const useToast = () => {

--- a/App/Client/src/i18n/i18n.ts
+++ b/App/Client/src/i18n/i18n.ts
@@ -1,5 +1,6 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+
 import en from './locales/en.json';
 import ja from './locales/ja.json';
 

--- a/App/Client/src/main.tsx
+++ b/App/Client/src/main.tsx
@@ -1,8 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
 import './i18n/i18n'
 import '@carbon/styles/css/styles.css'
 import './index.scss'
+
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(

--- a/App/Client/src/pages/ArticlePage.test.tsx
+++ b/App/Client/src/pages/ArticlePage.test.tsx
@@ -1,11 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
-import { ArticlePage } from './ArticlePage';
-import { AuthContext } from '../context/AuthContext';
-import { ToastProvider } from '../context/ToastContext';
+import { beforeEach,describe, expect, it, vi } from 'vitest';
+
 import { articlesApi } from '../api/articles';
 import { commentsApi } from '../api/comments';
+import { AuthContext } from '../context/AuthContext';
+import { ToastProvider } from '../context/ToastContext';
+import { ArticlePage } from './ArticlePage';
 
 // Mock the API modules
 vi.mock('../api/articles', () => ({

--- a/App/Client/src/pages/ArticlePage.tsx
+++ b/App/Client/src/pages/ArticlePage.tsx
@@ -1,20 +1,22 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { useParams, useNavigate, Link } from 'react-router';
-import { Grid, Column, Button, TextArea, Loading, Tile, Tag, IconButton, Form, InlineLoading, Breadcrumb, BreadcrumbItem } from '@carbon/react';
-import { FavoriteFilled, Favorite, Edit, TrashCan } from '@carbon/icons-react';
+import './ArticlePage.scss';
+
+import { Edit, Favorite, FavoriteFilled, TrashCan } from '@carbon/icons-react';
+import { Breadcrumb, BreadcrumbItem,Button, Column, Form, Grid, IconButton, InlineLoading, Loading, Tag, TextArea, Tile } from '@carbon/react';
+import React, { useCallback,useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAuth } from '../hooks/useAuth';
-import { useRequireAuth } from '../hooks/useRequireAuth';
-import { useToast } from '../hooks/useToast';
+import { Link,useNavigate, useParams } from 'react-router';
+
 import { articlesApi } from '../api/articles';
+import { ApiError } from '../api/client';
 import { commentsApi } from '../api/comments';
 import { profilesApi } from '../api/profiles';
 import { PageShell } from '../components/PageShell';
-import { ApiError } from '../api/client';
+import { COMMENT_CONSTRAINTS,DEFAULT_PROFILE_IMAGE } from '../constants';
+import { useAuth } from '../hooks/useAuth';
+import { useRequireAuth } from '../hooks/useRequireAuth';
+import { useToast } from '../hooks/useToast';
 import type { Article } from '../types/article';
 import type { Comment } from '../types/comment';
-import { DEFAULT_PROFILE_IMAGE, COMMENT_CONSTRAINTS } from '../constants';
-import './ArticlePage.scss';
 
 interface ArticleBannerProps {
   article: Article;

--- a/App/Client/src/pages/EditorPage.test.tsx
+++ b/App/Client/src/pages/EditorPage.test.tsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
-import { EditorPage } from './EditorPage';
+import { beforeEach,describe, expect, it, vi } from 'vitest';
+
 import { AuthContext } from '../context/AuthContext';
 import { ToastProvider } from '../context/ToastContext';
+import { EditorPage } from './EditorPage';
 
 // Mock the articles API
 vi.mock('../api/articles', () => ({

--- a/App/Client/src/pages/EditorPage.tsx
+++ b/App/Client/src/pages/EditorPage.tsx
@@ -1,21 +1,23 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { useParams, useNavigate } from 'react-router';
+import './EditorPage.scss';
+
 import {
-  Form,
-  TextInput,
-  TextArea,
   Button,
+  Form,
+  InlineLoading,
   Stack,
   Tag,
-  InlineLoading,
+  TextArea,
+  TextInput,
 } from '@carbon/react';
+import React, { useCallback,useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate,useParams } from 'react-router';
+
 import { articlesApi } from '../api/articles';
-import { useApiCall } from '../hooks/useApiCall';
 import { ErrorDisplay } from '../components/ErrorDisplay';
 import { PageShell } from '../components/PageShell';
 import { ARTICLE_CONSTRAINTS, TAG_CONSTRAINTS } from '../constants';
-import './EditorPage.scss';
+import { useApiCall } from '../hooks/useApiCall';
 
 export const EditorPage: React.FC = () => {
   const { t } = useTranslation();

--- a/App/Client/src/pages/ForbiddenPage.tsx
+++ b/App/Client/src/pages/ForbiddenPage.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
-import { Link } from 'react-router';
-import { useTranslation } from 'react-i18next';
-import { PageShell } from '../components/PageShell';
 import './ForbiddenPage.scss';
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+import { PageShell } from '../components/PageShell';
 
 export const ForbiddenPage: React.FC = () => {
   const { t } = useTranslation();

--- a/App/Client/src/pages/HomePage.scss
+++ b/App/Client/src/pages/HomePage.scss
@@ -10,14 +10,14 @@
   padding: $spacing-07 0;
   text-align: center;
   color: var(--cds-text-on-color);
-  box-shadow: inset 0 8px 8px -8px rgb(0 0 0 / 30%),
-              inset 0 -8px 8px -8px rgb(0 0 0 / 30%);
+  box-shadow: inset 0 8px 8px -8px var(--cds-shadow),
+              inset 0 -8px 8px -8px var(--cds-shadow);
 }
 
 .banner-title {
   @include type.type-style('heading-07');
 
-  text-shadow: 0 1px 3px rgb(0 0 0 / 30%);
+  text-shadow: 0 1px 3px var(--cds-shadow);
   margin-bottom: $spacing-03;
 }
 

--- a/App/Client/src/pages/HomePage.test.tsx
+++ b/App/Client/src/pages/HomePage.test.tsx
@@ -1,12 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { fireEvent,render, screen, waitFor } from '@testing-library/react'
 import { BrowserRouter } from 'react-router'
-import { HomePage } from './HomePage'
+import { beforeEach,describe, expect, it, vi } from 'vitest'
+
+import { articlesApi } from '../api/articles'
+import { authApi } from '../api/auth'
+import { tagsApi } from '../api/tags'
 import { AuthProvider } from '../context/AuthContext'
 import { ToastProvider } from '../context/ToastContext'
-import { authApi } from '../api/auth'
-import { articlesApi } from '../api/articles'
-import { tagsApi } from '../api/tags'
+import { HomePage } from './HomePage'
 
 vi.mock('../api/auth', () => ({
   authApi: {

--- a/App/Client/src/pages/HomePage.tsx
+++ b/App/Client/src/pages/HomePage.tsx
@@ -1,17 +1,19 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { Grid, Column, Tabs, TabList, Tab, TabPanels, TabPanel, Tile, Pagination } from '@carbon/react';
-import { useToast } from '../hooks/useToast';
+import './HomePage.scss';
+
+import { Column, Grid, Pagination,Tab, TabList, TabPanel, TabPanels, Tabs, Tile } from '@carbon/react';
+import React, { useCallback,useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAuth } from '../hooks/useAuth';
-import { useRequireAuth } from '../hooks/useRequireAuth';
+
 import { articlesApi } from '../api/articles';
+import { ApiError } from '../api/client';
 import { tagsApi } from '../api/tags';
 import { ArticleList } from '../components/ArticleList';
-import { TagList } from '../components/TagList';
 import { PageShell } from '../components/PageShell';
-import { ApiError } from '../api/client';
+import { TagList } from '../components/TagList';
+import { useAuth } from '../hooks/useAuth';
+import { useRequireAuth } from '../hooks/useRequireAuth';
+import { useToast } from '../hooks/useToast';
 import type { Article } from '../types/article';
-import './HomePage.scss';
 
 const DEFAULT_PAGE_SIZE = 20;
 const PAGE_SIZE_OPTIONS = [10, 20, 50, 100];

--- a/App/Client/src/pages/LoginPage.test.tsx
+++ b/App/Client/src/pages/LoginPage.test.tsx
@@ -1,12 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BrowserRouter } from 'react-router'
-import { LoginPage } from './LoginPage'
+import { beforeEach,describe, expect, it, vi } from 'vitest'
+
+import { authApi } from '../api/auth'
+import { ToastContainer } from '../components/ToastContainer'
 import { AuthProvider } from '../context/AuthContext'
 import { ToastProvider } from '../context/ToastContext'
-import { ToastContainer } from '../components/ToastContainer'
-import { authApi } from '../api/auth'
+import { LoginPage } from './LoginPage'
 
 vi.mock('../api/auth', () => ({
   authApi: {

--- a/App/Client/src/pages/LoginPage.tsx
+++ b/App/Client/src/pages/LoginPage.tsx
@@ -1,19 +1,21 @@
-import React, { useActionState, startTransition } from 'react';
-import { useNavigate, Link } from 'react-router';
+import './AuthPages.scss';
+
 import {
-  Form,
-  TextInput,
-  PasswordInput,
   Button,
-  Stack,
+  Form,
   InlineLoading,
+  PasswordInput,
+  Stack,
+  TextInput,
 } from '@carbon/react';
+import React, { startTransition,useActionState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAuth } from '../hooks/useAuth';
+import { Link,useNavigate } from 'react-router';
+
 import { ErrorDisplay } from '../components/ErrorDisplay';
 import { PageShell } from '../components/PageShell';
+import { useAuth } from '../hooks/useAuth';
 import { type AppError, normalizeError } from '../utils/errors';
-import './AuthPages.scss';
 
 interface LoginState {
   error: AppError | null;

--- a/App/Client/src/pages/ProfilePage.test.tsx
+++ b/App/Client/src/pages/ProfilePage.test.tsx
@@ -1,11 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { fireEvent,render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router';
-import { ProfilePage } from './ProfilePage';
+import { beforeEach,describe, expect, it, vi } from 'vitest';
+
+import { articlesApi } from '../api/articles';
+import { profilesApi } from '../api/profiles';
 import { AuthContext } from '../context/AuthContext';
 import { ToastProvider } from '../context/ToastContext';
-import { profilesApi } from '../api/profiles';
-import { articlesApi } from '../api/articles';
+import { ProfilePage } from './ProfilePage';
 
 // Mock the API modules
 vi.mock('../api/profiles', () => ({

--- a/App/Client/src/pages/ProfilePage.tsx
+++ b/App/Client/src/pages/ProfilePage.tsx
@@ -1,20 +1,22 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { useParams, Link } from 'react-router';
-import { Grid, Column, Button, Tabs, TabList, Tab, TabPanels, TabPanel, Loading, Pagination, Breadcrumb, BreadcrumbItem } from '@carbon/react';
+import './ProfilePage.scss';
+
 import { Settings } from '@carbon/icons-react';
+import { Breadcrumb, BreadcrumbItem,Button, Column, Grid, Loading, Pagination, Tab, TabList, TabPanel, TabPanels, Tabs } from '@carbon/react';
+import React, { useCallback,useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link,useParams } from 'react-router';
+
+import { articlesApi } from '../api/articles';
+import { ApiError } from '../api/client';
+import { profilesApi } from '../api/profiles';
+import { ArticleList } from '../components/ArticleList';
+import { PageShell } from '../components/PageShell';
+import { DEFAULT_PROFILE_IMAGE } from '../constants';
 import { useAuth } from '../hooks/useAuth';
 import { useRequireAuth } from '../hooks/useRequireAuth';
 import { useToast } from '../hooks/useToast';
-import { profilesApi } from '../api/profiles';
-import { articlesApi } from '../api/articles';
-import { ArticleList } from '../components/ArticleList';
-import { PageShell } from '../components/PageShell';
-import { ApiError } from '../api/client';
 import type { Profile } from '../types/article';
 import type { Article } from '../types/article';
-import { DEFAULT_PROFILE_IMAGE } from '../constants';
-import './ProfilePage.scss';
 
 const DEFAULT_PAGE_SIZE = 20;
 const PAGE_SIZE_OPTIONS = [10, 20, 50, 100];

--- a/App/Client/src/pages/RegisterPage.test.tsx
+++ b/App/Client/src/pages/RegisterPage.test.tsx
@@ -1,12 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BrowserRouter } from 'react-router'
-import { RegisterPage } from './RegisterPage'
+import { beforeEach,describe, expect, it, vi } from 'vitest'
+
+import { authApi } from '../api/auth'
+import { ToastContainer } from '../components/ToastContainer'
 import { AuthProvider } from '../context/AuthContext'
 import { ToastProvider } from '../context/ToastContext'
-import { ToastContainer } from '../components/ToastContainer'
-import { authApi } from '../api/auth'
+import { RegisterPage } from './RegisterPage'
 
 vi.mock('../api/auth', () => ({
   authApi: {

--- a/App/Client/src/pages/RegisterPage.tsx
+++ b/App/Client/src/pages/RegisterPage.tsx
@@ -1,20 +1,22 @@
-import React, { useActionState, startTransition } from 'react';
-import { useNavigate, Link } from 'react-router';
+import './AuthPages.scss';
+
 import {
-  Form,
-  TextInput,
-  PasswordInput,
   Button,
-  Stack,
+  Form,
   InlineLoading,
+  PasswordInput,
+  Stack,
+  TextInput,
 } from '@carbon/react';
+import React, { startTransition,useActionState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAuth } from '../hooks/useAuth';
+import { Link,useNavigate } from 'react-router';
+
 import { ErrorDisplay } from '../components/ErrorDisplay';
 import { PageShell } from '../components/PageShell';
 import { USER_CONSTRAINTS } from '../constants';
+import { useAuth } from '../hooks/useAuth';
 import { type AppError, normalizeError } from '../utils/errors';
-import './AuthPages.scss';
 
 interface RegisterState {
   error: AppError | null;

--- a/App/Client/src/pages/SettingsPage.test.tsx
+++ b/App/Client/src/pages/SettingsPage.test.tsx
@@ -1,12 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BrowserRouter } from 'react-router'
-import { SettingsPage } from './SettingsPage'
+import { beforeEach,describe, expect, it, vi } from 'vitest'
+
+import { authApi } from '../api/auth'
+import { ToastContainer } from '../components/ToastContainer'
 import { AuthProvider } from '../context/AuthContext'
 import { ToastProvider } from '../context/ToastContext'
-import { ToastContainer } from '../components/ToastContainer'
-import { authApi } from '../api/auth'
+import { SettingsPage } from './SettingsPage'
 
 vi.mock('../api/auth', () => ({
   authApi: {

--- a/App/Client/src/pages/SettingsPage.tsx
+++ b/App/Client/src/pages/SettingsPage.tsx
@@ -1,22 +1,24 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import './SettingsPage.scss';
+
 import {
-  Form,
-  TextInput,
-  TextArea,
-  PasswordInput,
   Button,
-  Stack,
   Dropdown,
+  Form,
   InlineLoading,
+  PasswordInput,
+  Stack,
+  TextArea,
+  TextInput,
 } from '@carbon/react';
+import React, { useCallback,useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAuth } from '../hooks/useAuth';
-import { useToast } from '../hooks/useToast';
-import { useApiCall } from '../hooks/useApiCall';
+
 import { ErrorDisplay } from '../components/ErrorDisplay';
 import { PageShell } from '../components/PageShell';
-import { USER_CONSTRAINTS, SUPPORTED_LANGUAGES } from '../constants';
-import './SettingsPage.scss';
+import { SUPPORTED_LANGUAGES,USER_CONSTRAINTS } from '../constants';
+import { useApiCall } from '../hooks/useApiCall';
+import { useAuth } from '../hooks/useAuth';
+import { useToast } from '../hooks/useToast';
 
 export const SettingsPage: React.FC = () => {
   const { t, i18n } = useTranslation();

--- a/App/Client/src/pages/UsersPage.test.tsx
+++ b/App/Client/src/pages/UsersPage.test.tsx
@@ -1,11 +1,12 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
-import { UsersPage } from './UsersPage';
-import { ToastProvider } from '../context/ToastContext';
-import { ToastContainer } from '../components/ToastContainer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { usersApi } from '../api/users';
+import { ToastContainer } from '../components/ToastContainer';
+import { ToastProvider } from '../context/ToastContext';
+import { UsersPage } from './UsersPage';
 
 vi.mock('../api/users', () => ({
   usersApi: {

--- a/App/Client/src/pages/UsersPage.tsx
+++ b/App/Client/src/pages/UsersPage.tsx
@@ -1,33 +1,35 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { Link } from 'react-router';
+import './UsersPage.scss';
+
+import { Add } from '@carbon/icons-react';
 import {
-  DataTable,
-  TableContainer,
-  Table,
-  TableHead,
-  TableRow,
-  TableHeader,
-  TableBody,
-  TableCell,
   Button,
-  Modal,
-  TextInput,
-  PasswordInput,
-  Loading,
-  Pagination,
-  Tag,
   Checkbox,
+  DataTable,
+  Loading,
+  Modal,
   OverflowMenu,
   OverflowMenuItem,
+  Pagination,
+  PasswordInput,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Tag,
+  TextInput,
 } from '@carbon/react';
-import { Add } from '@carbon/icons-react';
+import React, { useCallback,useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+
+import { ApiError } from '../api/client';
+import { type User,usersApi } from '../api/users';
 import { PageShell } from '../components/PageShell';
-import { usersApi, type User } from '../api/users';
 import { useAuth } from '../hooks/useAuth';
 import { useToast } from '../hooks/useToast';
-import { ApiError } from '../api/client';
-import './UsersPage.scss';
 
 const DEFAULT_PAGE_SIZE = 20;
 const PAGE_SIZE_OPTIONS = [10, 20, 50];

--- a/App/Client/src/utils/errors.test.ts
+++ b/App/Client/src/utils/errors.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest';
-import { normalizeError, AppError } from './errors';
+import { describe, expect,it } from 'vitest';
+
 import { ApiError } from '../api/client';
+import { AppError,normalizeError } from './errors';
 
 describe('normalizeError', () => {
   describe('ApiError normalization', () => {

--- a/App/Client/vite.config.ts
+++ b/App/Client/vite.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
 import basicSsl from '@vitejs/plugin-basic-ssl'
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
 
 // https://vite.dev/config/
 export default defineConfig({

--- a/App/Client/vitest.config.ts
+++ b/App/Client/vitest.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vitest/config'
 import TrxReporter from 'vitest-trx-results-processor'
 
 // https://vitejs.dev/config/


### PR DESCRIPTION
## Summary
- Add `@typescript-eslint/no-explicit-any` ESLint rule (error) to ban explicit `any` type annotations
- Add `eslint-plugin-simple-import-sort` to enforce consistent import ordering (auto-fixed all existing files)
- Remove `rgb()` and `white` from stylelint `carbon/theme-use` whitelist — hardcoded shadow colors in HomePage.scss replaced with `var(--cds-shadow)`, hardcoded `color: white` in ArticlePreview.scss replaced with `var(--cds-text-on-color)`

## Test plan
- [x] `LintClientVerify` passes (ESLint + stylelint + locale parity)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)