### PR TITLE
fix: extract shared CSS utilities for avatars, banners, and hr (#11, #12, #13)

### DIFF
--- a/App/Client/src/components/ArticlePreview.scss
+++ b/App/Client/src/components/ArticlePreview.scss
@@ -21,9 +21,6 @@
 }
 
 .author-image {
-  width: $spacing-07;
-  height: $spacing-07;
-  border-radius: 50%;
   margin-right: $spacing-03;
 }
 

--- a/App/Client/src/components/ArticlePreview.tsx
+++ b/App/Client/src/components/ArticlePreview.tsx
@@ -45,7 +45,7 @@ export const ArticlePreview: React.FC<ArticlePreviewProps> = ({
           <img
             src={article.author.image || DEFAULT_PROFILE_IMAGE}
             alt={article.author.username}
-            className="author-image"
+            className="author-image avatar-md"
           />
           <div className="author-details">
             <span className="author-name cds--text-truncate-end" title={article.author.username}>{article.author.username}</span>

--- a/App/Client/src/index.scss
+++ b/App/Client/src/index.scss
@@ -1,5 +1,6 @@
 @use '@carbon/react/scss/theme' as *;
 @use '@carbon/react/scss/breakpoint' as *;
+@use '@carbon/react/scss/spacing' as *;
 @use '@carbon/styles/scss/components/ui-shell/functions' as shell;
 
 :root {
@@ -36,6 +37,34 @@ a {
 a:hover {
   color: var(--cds-link-primary-hover);
   text-decoration: underline;
+}
+
+hr {
+  margin: $spacing-07 0;
+  border: 0;
+  border-top: 1px solid var(--cds-border-subtle);
+}
+
+.avatar-sm {
+  width: $spacing-06;
+  height: $spacing-06;
+  border-radius: 50%;
+}
+
+.avatar-md {
+  width: $spacing-07;
+  height: $spacing-07;
+  border-radius: 50%;
+}
+
+.avatar-lg {
+  width: $spacing-12;
+  height: $spacing-12;
+  border-radius: 50%;
+}
+
+.page-banner {
+  padding: $spacing-07 0;
 }
 
 .loading-fullscreen {

--- a/App/Client/src/pages/ArticlePage.scss
+++ b/App/Client/src/pages/ArticlePage.scss
@@ -27,7 +27,6 @@
 .article-page .banner {
   background: var(--cds-background-inverse);
   color: var(--cds-text-on-color);
-  padding: $spacing-07 0;
 }
 
 .article-page .banner h1 {
@@ -51,10 +50,7 @@
   overflow: hidden;
 }
 
-.article-meta img {
-  width: $spacing-07;
-  height: $spacing-07;
-  border-radius: 50%;
+.article-meta .avatar-md {
   margin-right: $spacing-03;
 }
 
@@ -149,12 +145,6 @@
   color: inherit;
   gap: $spacing-03;
   overflow: hidden;
-}
-
-.comment-author-img {
-  width: $spacing-06;
-  height: $spacing-06;
-  border-radius: 50%;
 }
 
 .comment-author-name {

--- a/App/Client/src/pages/ArticlePage.tsx
+++ b/App/Client/src/pages/ArticlePage.tsx
@@ -37,13 +37,13 @@ const ArticleBanner: React.FC<ArticleBannerProps> = ({
 }) => {
   const { t } = useTranslation();
   return (
-  <div className="banner">
+  <div className="page-banner banner">
     <Grid>
       <Column lg={16} md={8} sm={4}>
         <h1>{article.title}</h1>
         <div className="article-meta">
         <Link to={`/profile/${article.author.username}`} className="author-info">
-          <img src={article.author.image || DEFAULT_PROFILE_IMAGE} alt={article.author.username} />
+          <img src={article.author.image || DEFAULT_PROFILE_IMAGE} alt={article.author.username} className="avatar-md" />
           <div className="info">
             <span className="author cds--text-truncate-end" title={article.author.username}>{article.author.username}</span>
             <span className="date">{new Date(article.createdAt).toLocaleDateString()}</span>
@@ -287,7 +287,7 @@ export const ArticlePage: React.FC = () => {
                   <img
                     src={user.image || DEFAULT_PROFILE_IMAGE}
                     alt={user.username}
-                    className="comment-author-img"
+                    className="avatar-sm"
                   />
                   <Button type="submit" size="sm" disabled={submitting || !commentBody.trim()}>
                     {t('article.comments.submit')}
@@ -312,7 +312,7 @@ export const ArticlePage: React.FC = () => {
                   <img
                     src={comment.author.image || DEFAULT_PROFILE_IMAGE}
                     alt={comment.author.username}
-                    className="comment-author-img"
+                    className="avatar-sm"
                   />
                   <span className="comment-author-name cds--text-truncate-end" title={comment.author.username}>{comment.author.username}</span>
                 </Link>

--- a/App/Client/src/pages/HomePage.scss
+++ b/App/Client/src/pages/HomePage.scss
@@ -3,7 +3,6 @@
 
 .banner {
   background: linear-gradient(135deg, var(--cds-link-primary) 0%, var(--cds-link-visited) 100%);
-  padding: $spacing-07 0;
   text-align: center;
   color: var(--cds-text-on-color);
   box-shadow: inset 0 $spacing-03 $spacing-03 (-$spacing-03) var(--cds-shadow),

--- a/App/Client/src/pages/HomePage.tsx
+++ b/App/Client/src/pages/HomePage.tsx
@@ -21,7 +21,7 @@ const PAGE_SIZE_OPTIONS = [10, 20, 50, 100];
 const HomeBanner: React.FC = () => {
   const { t } = useTranslation();
   return (
-    <div className="banner">
+    <div className="page-banner banner">
       <Grid>
         <Column lg={16} md={8} sm={4}>
           <h1 className="banner-title">{t('home.bannerTitle')}</h1>

--- a/App/Client/src/pages/ProfilePage.scss
+++ b/App/Client/src/pages/ProfilePage.scss
@@ -27,14 +27,10 @@
 
 .user-info {
   background: var(--cds-layer-01);
-  padding: $spacing-07 0;
   text-align: center;
 }
 
 .user-img {
-  width: $spacing-12;
-  height: $spacing-12;
-  border-radius: 50%;
   margin-bottom: $spacing-05;
 }
 

--- a/App/Client/src/pages/ProfilePage.tsx
+++ b/App/Client/src/pages/ProfilePage.tsx
@@ -30,13 +30,13 @@ interface ProfileBannerProps {
 const ProfileBanner: React.FC<ProfileBannerProps> = ({ profile, isOwnProfile, onFollow }) => {
   const { t } = useTranslation();
   return (
-  <div className="user-info">
+  <div className="page-banner user-info">
     <Grid>
       <Column lg={{ span: 14, offset: 1 }} md={8} sm={4}>
           <img
             src={profile.image || DEFAULT_PROFILE_IMAGE}
             alt={profile.username}
-            className="user-img"
+            className="user-img avatar-lg"
           />
           <h4 title={profile.username}>{profile.username}</h4>
           <p>{profile.bio}</p>

--- a/App/Client/src/pages/SettingsPage.scss
+++ b/App/Client/src/pages/SettingsPage.scss
@@ -3,9 +3,3 @@
 .settings-page {
   padding: $spacing-06 0;
 }
-
-.settings-page hr {
-  margin: $spacing-07 0;
-  border: 0;
-  border-top: 1px solid var(--cds-border-subtle);
-}

--- a/Docs/carbon-audit2.md
+++ b/Docs/carbon-audit2.md
@@ -216,7 +216,7 @@ Three different approaches to full-height pages:
 
 ---
 
-### 11. `<hr>` With Custom/Missing Styling
+### ~~11. `<hr>` With Custom/Missing Styling~~ FIXED
 
 **Severity:** Low
 **Files:** `SettingsPage.scss:8-11`, `ArticlePage.tsx:269`
@@ -233,9 +233,11 @@ And `ArticlePage.tsx:269` has a bare `<hr />` with no class — it inherits brow
 
 **Recommendation:** Extract a shared `.divider` class or add a global `hr` reset in `index.scss` that uses Carbon border tokens consistently.
 
+**Resolution:** Added a global `hr` reset in `index.scss` using `$spacing-07` margin and `var(--cds-border-subtle)` border. Removed the dead `.settings-page hr` rule from `SettingsPage.scss` (SettingsPage.tsx has no `<hr>` elements).
+
 ---
 
-### 12. Repeated Avatar `border-radius: 50%`
+### ~~12. Repeated Avatar `border-radius: 50%`~~ FIXED
 
 **Severity:** Low
 **Files:** `ArticlePreview.scss`, `ArticlePage.scss`, `ProfilePage.scss`
@@ -251,9 +253,11 @@ Four separate declarations of the same circular avatar pattern.
 
 **Recommendation:** Extract a shared `.avatar` SCSS class (or mixin) that handles the `border-radius: 50%` + sizing, and apply it in one place. Could have `.avatar--sm` (24px), `.avatar--md` (32px), `.avatar--lg` (100px) variants using spacing tokens.
 
+**Resolution:** Added three global avatar utility classes in `index.scss`: `.avatar-sm` (`$spacing-06`), `.avatar-md` (`$spacing-07`), `.avatar-lg` (`$spacing-12`), each with `border-radius: 50%`. Stripped sizing/rounding from the four component-level selectors, keeping only contextual margins. Replaced `.article-meta img` element selector with class-based `.article-meta .avatar-md`. Deleted `.comment-author-img` block entirely.
+
 ---
 
-### 13. Banner Pattern Duplicated
+### ~~13. Banner Pattern Duplicated~~ FIXED
 
 **Severity:** Low
 **Files:** `HomePage.scss`, `ArticlePage.scss`, `ProfilePage.scss`
@@ -261,6 +265,8 @@ Four separate declarations of the same circular avatar pattern.
 Three pages have their own banner implementations with duplicated inner styles (padding `$spacing-07 0`, Grid wrapping, full-width background). The `PageShell` banner prop handles placement, but the banner content styles are repeated.
 
 **Recommendation:** Extract a shared `.page-banner` base class for the common padding/layout pattern.
+
+**Resolution:** Added `.page-banner` base class in `index.scss` with the shared `padding: $spacing-07 0`. Removed padding from the three page-specific banner selectors. Composed the base class on each banner `<div>` in TSX (`className="page-banner banner"`, `className="page-banner user-info"`).
 
 ---
 
@@ -332,10 +338,10 @@ Either use `stylelint-declaration-strict-value` for `z-index` to require variabl
 | 8 | High | `window.confirm()` + missing i18n | ArticlePage |
 | 9 | Low | Manual flex stacks could use `<Stack>` | Multiple (5 files) |
 | ~~10~~ | ~~Low~~ | ~~Inconsistent full-height approach~~ | ~~6 page files~~ |
-| 11 | Low | Unstyled `<hr>` / duplicate styling | ArticlePage, SettingsPage |
-| 12 | Low | Repeated avatar `border-radius: 50%` | 4 files |
-| 13 | Low | Banner padding pattern duplicated | 3 page files |
+| ~~11~~ | ~~Low~~ | ~~Unstyled `<hr>` / duplicate styling~~ | ~~ArticlePage, SettingsPage~~ |
+| ~~12~~ | ~~Low~~ | ~~Repeated avatar `border-radius: 50%`~~ | ~~4 files~~ |
+| ~~13~~ | ~~Low~~ | ~~Banner padding pattern duplicated~~ | ~~3 page files~~ |
 
 **High:** 1 finding (window.confirm)
 **Medium:** 0 findings remaining
-**Low:** 4 findings remaining (DRY/consistency improvements)
+**Low:** 1 finding remaining (#9 — manual flex stacks could use `<Stack>`)


### PR DESCRIPTION
## Summary

- **#11 — Global `<hr>` reset:** Added Carbon-tokenized `hr` style in `index.scss`, removed dead `.settings-page hr` rule (SettingsPage has no `<hr>` elements)
- **#12 — Avatar utility classes:** Added `.avatar-sm`/`.avatar-md`/`.avatar-lg` in `index.scss`, replacing 4 duplicated `border-radius: 50%` + sizing declarations across ArticlePreview, ArticlePage, and ProfilePage
- **#13 — Banner base class:** Added `.page-banner` in `index.scss` with shared `padding: $spacing-07 0`, removing duplication from HomePage, ArticlePage, and ProfilePage banner selectors

## Test plan

- [x] `LintAllVerify` passes (stylelint + ESLint + all other lint targets)
- [ ] Visual verification: avatars render correctly at all three sizes (sm/md/lg)
- [ ] Visual verification: banners retain correct padding on HomePage, ArticlePage, ProfilePage
- [ ] Visual verification: `<hr>` on ArticlePage renders with Carbon border token

🤖 Generated with [Claude Code](https://claude.com/claude-code)