### PR TITLE
refactor: deduplicate SCSS shared utilities into index.scss

### DIFF
--- a/App/Client/src/components/ArticlePreview.scss
+++ b/App/Client/src/components/ArticlePreview.scss
@@ -7,9 +7,6 @@
 }
 
 .article-meta {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
   margin-bottom: $spacing-05;
 }
 
@@ -74,8 +71,3 @@
   color: var(--cds-text-placeholder);
 }
 
-.article-tags {
-  display: flex;
-  gap: $spacing-02;
-  flex-wrap: wrap;
-}

--- a/App/Client/src/components/ArticlePreview.tsx
+++ b/App/Client/src/components/ArticlePreview.tsx
@@ -66,7 +66,7 @@ export const ArticlePreview: React.FC<ArticlePreviewProps> = ({
         <p className="article-description">{article.description}</p>
         <div className="article-footer">
           <span className="read-more">{t('article.readMore')}</span>
-          <div className="article-tags">
+          <div className="tag-list">
             {article.tagList.map((tag) => (
               <Tag key={tag} type="outline" size="sm">
                 {tag}

--- a/App/Client/src/components/TagList.scss
+++ b/App/Client/src/components/TagList.scss
@@ -1,11 +1,5 @@
 @use '@carbon/react/scss/spacing' as *;
 
-.tag-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: $spacing-03;
-}
-
 .tag-list-loading,
 .tag-list-empty {
   padding: $spacing-05;

--- a/App/Client/src/index.scss
+++ b/App/Client/src/index.scss
@@ -74,3 +74,37 @@ hr {
   height: 100vh;
 }
 
+/* Shared layout utilities */
+.article-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-03;
+}
+
+/* Breadcrumb overflow — prevents long titles breaking layout */
+.cds--breadcrumb {
+  margin-bottom: $spacing-05;
+}
+
+.cds--breadcrumb-item:last-child {
+  overflow: hidden;
+
+  .cds--link {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+/* Standard page content padding */
+.auth-page,
+.editor-page,
+.settings-page {
+  padding: $spacing-06 0;
+}
+

--- a/App/Client/src/pages/ArticlePage.scss
+++ b/App/Client/src/pages/ArticlePage.scss
@@ -1,22 +1,6 @@
 @use '@carbon/react/scss/spacing' as *;
 @use '@carbon/react/scss/type' as type;
 
-.article-page {
-  .cds--breadcrumb {
-    margin-bottom: $spacing-05;
-  }
-
-  .cds--breadcrumb-item:last-child {
-    overflow: hidden;
-
-    .cds--link {
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-  }
-
-}
-
 .article-page.loading {
   display: flex;
   justify-content: center;
@@ -34,12 +18,6 @@
 
   margin-bottom: $spacing-06;
   overflow-wrap: break-word;
-}
-
-.article-meta {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
 }
 
 .article-meta .author-info {
@@ -91,10 +69,7 @@
   overflow-wrap: break-word;
 }
 
-.article-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: $spacing-03;
+.article-page .tag-list {
   margin-bottom: $spacing-06;
 }
 

--- a/App/Client/src/pages/ArticlePage.tsx
+++ b/App/Client/src/pages/ArticlePage.tsx
@@ -259,7 +259,7 @@ export const ArticlePage: React.FC = () => {
               <p key={index}>{paragraph}</p>
             ))}
           </div>
-          <div className="article-tags">
+          <div className="tag-list">
             {article.tagList.map(tag => (
               <Tag key={tag} type="outline" size="sm" as={Link} to={`/?tag=${tag}`}>
                 {tag}

--- a/App/Client/src/pages/AuthPages.scss
+++ b/App/Client/src/pages/AuthPages.scss
@@ -1,5 +1,0 @@
-@use '@carbon/react/scss/spacing' as *;
-
-.auth-page {
-  padding: $spacing-06 0;
-}

--- a/App/Client/src/pages/EditorPage.scss
+++ b/App/Client/src/pages/EditorPage.scss
@@ -1,12 +1,5 @@
 @use '@carbon/react/scss/spacing' as *;
 
-.editor-page {
-  padding: $spacing-06 0;
-}
-
 .editor-page .tag-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: $spacing-03;
   margin-top: $spacing-03;
 }

--- a/App/Client/src/pages/LoginPage.tsx
+++ b/App/Client/src/pages/LoginPage.tsx
@@ -1,5 +1,3 @@
-import './AuthPages.scss';
-
 import {
   Button,
   Form,

--- a/App/Client/src/pages/ProfilePage.scss
+++ b/App/Client/src/pages/ProfilePage.scss
@@ -1,23 +1,6 @@
 @use '@carbon/react/scss/spacing' as *;
 @use '@carbon/react/scss/type' as type;
 
-.profile-page {
-  .cds--breadcrumb {
-    margin-bottom: $spacing-05;
-  }
-
-  .cds--breadcrumb-item:last-child {
-    overflow: hidden;
-
-    .cds--link {
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-  }
-
-
-}
-
 .profile-page.loading {
   display: flex;
   justify-content: center;

--- a/App/Client/src/pages/RegisterPage.tsx
+++ b/App/Client/src/pages/RegisterPage.tsx
@@ -1,5 +1,3 @@
-import './AuthPages.scss';
-
 import {
   Button,
   Form,

--- a/App/Client/src/pages/SettingsPage.scss
+++ b/App/Client/src/pages/SettingsPage.scss
@@ -1,5 +1,0 @@
-@use '@carbon/react/scss/spacing' as *;
-
-.settings-page {
-  padding: $spacing-06 0;
-}

--- a/App/Client/src/pages/SettingsPage.tsx
+++ b/App/Client/src/pages/SettingsPage.tsx
@@ -1,5 +1,3 @@
-import './SettingsPage.scss';
-
 import {
   Button,
   Dropdown,

--- a/Test/e2e/E2eTests/PageModels/ArticlePage.cs
+++ b/Test/e2e/E2eTests/PageModels/ArticlePage.cs
@@ -225,7 +225,7 @@ public class ArticlePage : BasePage
   }
 
   public ILocator GetArticleTag(string tagName) =>
-    Page.Locator(".article-tags .cds--tag").Filter(new() { HasText = tagName });
+    Page.Locator(".tag-list .cds--tag").Filter(new() { HasText = tagName });
 
   public async Task VerifyArticleTagsVisibleAsync(params string[] tags)
   {


### PR DESCRIPTION
## Summary
- Consolidate repeated SCSS patterns (`.article-meta`, `.tag-list`, breadcrumb overflow, page padding) into `index.scss` as shared utilities
- Unify `.article-tags` and `.tag-list` class names with consistent `$spacing-03` gap
- Delete `AuthPages.scss` and `SettingsPage.scss` (only contained the now-global padding rule)
- Net reduction: **-45 lines** of duplicated SCSS across 8 files

## Test plan
- [x] `LintClientVerify` — stylelint + ESLint pass
- [x] `BuildClient` — TypeScript compiles
- [x] `TestClient` — frontend tests pass
- [ ] `TestE2e` — E2E tests pass (breadcrumb, article, profile, editor, auth, settings pages)
- [ ] Visual verification: tag spacing, breadcrumb truncation, page padding all preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)