### PR TITLE
refactor: replace flex patterns with Carbon Stack and consolidate loading states

### DIFF
--- a/App/Client/src/index.scss
+++ b/App/Client/src/index.scss
@@ -74,6 +74,13 @@ hr {
   height: 100vh;
 }
 
+.page-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 50vh;
+}
+
 /* Shared layout utilities */
 .article-meta {
   display: flex;

--- a/App/Client/src/pages/ArticlePage.scss
+++ b/App/Client/src/pages/ArticlePage.scss
@@ -1,13 +1,6 @@
 @use '@carbon/react/scss/spacing' as *;
 @use '@carbon/react/scss/type' as type;
 
-.article-page.loading {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 50vh;
-}
-
 .article-page .banner {
   background: var(--cds-background-inverse);
   color: var(--cds-text-on-color);
@@ -46,11 +39,6 @@
   @include type.type-style('label-01');
 
   color: var(--cds-text-on-color-disabled);
-}
-
-.article-meta .actions {
-  display: flex;
-  gap: $spacing-03;
 }
 
 .article-content {

--- a/App/Client/src/pages/ArticlePage.tsx
+++ b/App/Client/src/pages/ArticlePage.tsx
@@ -50,7 +50,7 @@ const ArticleBanner: React.FC<ArticleBannerProps> = ({
           </Stack>
         </Link>
         {isAuthor ? (
-          <div className="actions">
+          <Stack orientation="horizontal" gap={3}>
             <Button
               kind="ghost"
               size="sm"
@@ -67,9 +67,9 @@ const ArticleBanner: React.FC<ArticleBannerProps> = ({
             >
               {t('article.deleteArticle')}
             </Button>
-          </div>
+          </Stack>
         ) : (
-          <div className="actions">
+          <Stack orientation="horizontal" gap={3}>
             <Button
               kind="ghost"
               size="sm"
@@ -85,7 +85,7 @@ const ArticleBanner: React.FC<ArticleBannerProps> = ({
             >
               {article.favorited ? t('article.unfavorite') : t('article.favorite')} ({article.favoritesCount})
             </Button>
-          </div>
+          </Stack>
         )}
       </div>
       </Column>
@@ -214,7 +214,7 @@ export const ArticlePage: React.FC = () => {
 
   if (loading) {
     return (
-      <PageShell className="article-page loading">
+      <PageShell className="article-page page-loading">
         <Loading description={t('article.loading')} withOverlay={false} />
       </PageShell>
     );

--- a/App/Client/src/pages/ProfilePage.scss
+++ b/App/Client/src/pages/ProfilePage.scss
@@ -1,13 +1,6 @@
 @use '@carbon/react/scss/spacing' as *;
 @use '@carbon/react/scss/type' as type;
 
-.profile-page.loading {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  min-height: 50vh;
-}
-
 .user-info {
   background: var(--cds-layer-01);
   text-align: center;

--- a/App/Client/src/pages/ProfilePage.tsx
+++ b/App/Client/src/pages/ProfilePage.tsx
@@ -175,7 +175,7 @@ export const ProfilePage: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="profile-page loading">
+      <div className="profile-page page-loading">
         <Loading description={t('profile.loading')} withOverlay={false} />
       </div>
     );


### PR DESCRIPTION
## Summary
- Replace custom `display: flex; gap` CSS for article page actions with Carbon's `<Stack orientation="horizontal" gap={3}>` component, eliminating the `.article-meta .actions` SCSS block
- Consolidate identical `.article-page.loading` and `.profile-page.loading` patterns into a shared `.page-loading` utility class in `index.scss`
- Net: -12 lines SCSS, +6 lines shared utility — 5 files touched

## Test plan
- [x] `BuildClient` passes
- [x] `LintAllVerify` passes (ESLint, stylelint, server lint)
- [x] `TestE2e` full suite passes (article page actions, profile page loading exercised)

🤖 Generated with [Claude Code](https://claude.com/claude-code)