### PR TITLE
fix: remove legacy page padding that doubled editor page spacing

### DIFF
--- a/App/Client/src/index.scss
+++ b/App/Client/src/index.scss
@@ -108,10 +108,4 @@ hr {
   }
 }
 
-/* Standard page content padding */
-.auth-page,
-.editor-page,
-.settings-page {
-  padding: $spacing-06 0;
-}
 


### PR DESCRIPTION
## Summary
- Removed dead CSS rule in `index.scss` that applied `$spacing-06` padding to `.editor-page`, `.auth-page`, and `.settings-page`
- This padding stacked on top of PageShell's `$spacing-07` grid padding, causing the editor page to have 56px gap between header and title vs 32px on other pages
- `.auth-page` and `.settings-page` selectors were dead code (no component uses those class names)

## Test plan
- [x] Visually verified editor page spacing now matches Settings and Home pages
- [x] Pre-commit lint passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)