### PR TITLE
add sharplens mcp server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -12,6 +12,14 @@
     "microsoft-learn": {
       "type": "http",
       "url": "https://learn.microsoft.com/api/mcp"
+    },
+    "sharplens": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "sharplens-mcp"],
+      "env": {
+        "DOTNET_SOLUTION_PATH": "${CLAUDE_PROJECT_DIR}/All.sln"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds the SharpLens MCP server (Roslyn-powered C# semantic analysis) to `.mcp.json`
- Uses `${CLAUDE_PROJECT_DIR}/All.sln` for the solution path so it resolves correctly across worktrees and dev machines

## Test plan
- [ ] CI passes (workflow should skip anyway — `.mcp.json` is not in any gated path)
- [ ] Restart Claude Code session and verify `sharplens` tools load

🤖 Generated with [Claude Code](https://claude.com/claude-code)