### PR TITLE
fix sharplens mcp solution path

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -18,7 +18,7 @@
       "command": "npx",
       "args": ["-y", "sharplens-mcp"],
       "env": {
-        "DOTNET_SOLUTION_PATH": "${CLAUDE_PROJECT_DIR}/All.sln"
+        "DOTNET_SOLUTION_PATH": "${PWD}/All.sln"
       }
     }
   }


### PR DESCRIPTION
## Summary
- Replace `${CLAUDE_PROJECT_DIR}` with `${PWD}` in the sharplens MCP server `env` block
- `CLAUDE_PROJECT_DIR` is only expanded in hook commands (`.claude/settings.json`), not in `.mcp.json` env blocks (see claude-code issues #9427, #2065)
- Without this fix, `DOTNET_SOLUTION_PATH` resolves to a literal unexpanded string and sharplens cannot load the solution

## Test plan
- [ ] Restart Claude Code session so `.mcp.json` is re-read
- [ ] Confirm sharplens MCP server starts and `roslyn_health_check` reports the solution loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)