### PR TITLE
Add Codex setup: AGENTS.md + .codex/config.toml

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,20 @@
+# Codex project config for Conduit (realworld-vibe-coded).
+#
+# YOLO mode: bypasses all approvals AND disables the sandbox — equivalent to
+# Claude Code's --dangerously-skip-permissions. Codex can read/write anywhere,
+# run any command, and use the network without asking.
+#
+# This file is ONLY loaded when the project is marked trusted in ~/.codex/config.toml:
+#
+#     [projects."/home/me/source/realworld-vibe-coded"]
+#     trust_level = "trusted"
+#
+# Without that entry, Codex ignores this file entirely. Run `codex` once in this
+# directory and it will prompt to trust; accept, and the trust entry is written
+# for you.
+
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+
+# Live web search (fetches current pages, not the cached OpenAI index).
+web_search = "live"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Agent Instructions
+
+The canonical instructions for any coding agent working in this repo live in
+[CLAUDE.md](./CLAUDE.md). Read it in full before making changes — it covers
+invariants, build commands (`./build.sh ...`, never `dotnet` directly), code
+conventions, protected files, and the rules index under `.claude/rules/`.
+
+This file exists so non-Claude agents (Codex, Cursor, etc.) discover those
+instructions via the [AGENTS.md](https://agents.md/) convention. The content
+is not duplicated here — edit `CLAUDE.md`, and every agent picks up the change.


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` that points agents at `CLAUDE.md` as the single source of truth — zero content duplication, cross-platform (plain file, not a symlink).
- Add `.codex/config.toml` configuring Codex in YOLO mode (`approval_policy = "never"`, `sandbox_mode = "danger-full-access"`) with live web search — mirrors Claude Code's `--dangerously-skip-permissions` posture for this repo.

## How it works
- `AGENTS.md` is the convention non-Claude agents (Codex, Cursor, etc.) discover per the [agents.md spec](https://agents.md/). It points at `CLAUDE.md`, which already contains the invariants, rules index, and build commands.
- `.codex/config.toml` is only loaded when the project is marked trusted in `~/.codex/config.toml`:
  ```toml
  [projects."/home/me/source/realworld-vibe-coded"]
  trust_level = "trusted"
  ```
  Running `codex` in this directory once will prompt to trust and write the entry automatically.

## Test plan
- [ ] `codex` launched in a trusted checkout loads `.codex/config.toml` and runs without approval prompts
- [ ] Live web search works from within a Codex session (e.g. ask for current docs on a library)
- [ ] Codex reads `AGENTS.md` → navigates to `CLAUDE.md` → follows the `.claude/rules/` index

🤖 Generated with [Claude Code](https://claude.com/claude-code)