### PR TITLE
add SessionStart hook to install git hooks

### DIFF
--- a/.claude/hooks/on-session-start.sh
+++ b/.claude/hooks/on-session-start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+./build.sh InstallGitHooks --agent >/dev/null 2>&1 &
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -68,6 +68,17 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/on-session-start.sh"
+          }
+        ]
+      }
     ]
   },
   "allowedTools": [

--- a/README.md
+++ b/README.md
@@ -184,3 +184,4 @@ This implementation has been generalized into reusable starter templates:
 
 - [**Single-Tenant Starter Template**](https://github.com/james-s-tayler/realworld-vibe-coded/tree/single-tenant-starter-template) — the same architecture without multi-tenancy, using SQLite
 - [**Multi-Tenant Starter Template**](https://github.com/james-s-tayler/realworld-vibe-coded/tree/multi-tenant-starter-template) — adds Finbuckle multi-tenancy, SQL Server, tenant-scoped data isolation
+


### PR DESCRIPTION
## Summary
- Adds `.claude/hooks/on-session-start.sh` that backgrounds `./build.sh InstallGitHooks --agent`
- Registers it under `SessionStart` with `matcher: "startup"` so it only fires on fresh session start (not `resume`/`clear`/`compact`)
- Ensures husky git hooks are installed automatically when entering a new worktree session

## Notes
- `InstallGitHooks` runs `npm ci` + `npm run prepare` (husky). Cheap and idempotent — safe to run unconditionally on startup.
- Hook backgrounds the command and exits immediately so session startup isn't delayed.
- Doesn't use `WorktreeCreate` (that hook replaces the default creation behavior and doesn't fire for re-entry or externally-created worktrees).

## Test plan
- [ ] Start a fresh session in a worktree — verify husky hooks install without manual intervention
- [ ] Start a fresh session in the main repo — same behavior
- [ ] `/clear` does not re-trigger the hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)